### PR TITLE
add missing file for clip score

### DIFF
--- a/examples/stable_diffusion_v2/eval/clip_score/utils/__init__.py
+++ b/examples/stable_diffusion_v2/eval/clip_score/utils/__init__.py
@@ -1,5 +1,5 @@
 """utils init"""
-from .compute_torch import compute_torchmetric_clip
+from .compute_metrics import compute_torchmetric_clip
 from .parse_yaml import *
 
 __all__ = ["compute_torchmetric_clip"]

--- a/examples/stable_diffusion_v2/eval/clip_score/utils/compute_metrics.py
+++ b/examples/stable_diffusion_v2/eval/clip_score/utils/compute_metrics.py
@@ -1,0 +1,18 @@
+def compute_torchmetric_clip(images, texts, model_name):
+    import torch
+    from torchmetrics.functional.multimodal import clip_score
+    from functools import partial
+    import torchvision.transforms as transforms
+
+    clip_score_fn = partial(clip_score, model_name_or_path=model_name)
+    transform = transforms.Compose([transforms.PILToTensor()])
+
+    images_ = []
+    for image in images:
+        img = transform(image)
+        if img.shape[0] == 4:
+            img = img[:3, :, :]
+        images_.append(img)
+    images = torch.stack(images_)
+    score = clip_score_fn(images, texts).detach()
+    return float(score)

--- a/examples/stable_diffusion_v2/eval/clip_score/utils/compute_metrics.py
+++ b/examples/stable_diffusion_v2/eval/clip_score/utils/compute_metrics.py
@@ -1,8 +1,14 @@
-def compute_torchmetric_clip(images, texts, model_name):
-    import torch
-    from torchmetrics.functional.multimodal import clip_score
+def compute_torchmetric_clip(images, texts, model_name, no_check_certificate=False):
     from functools import partial
+
+    import torch
     import torchvision.transforms as transforms
+    from torchmetrics.functional.multimodal import clip_score
+
+    if no_check_certificate:
+        import os
+
+        os.environ["CURL_CA_BUNDLE"] = ""
 
     clip_score_fn = partial(clip_score, model_name_or_path=model_name)
     transform = transforms.Compose([transforms.PILToTensor()])

--- a/examples/stable_diffusion_v2/eval/eval_clip_score.py
+++ b/examples/stable_diffusion_v2/eval/eval_clip_score.py
@@ -109,19 +109,13 @@ if __name__ == "__main__":
     if args.backend == "pt":
         from clip_score import compute_torchmetric_clip
 
-        # equivalent to no-check-certificate flag in wget
-        if args.no_check_certificate:
-            import os
-
-            os.environ["CURL_CA_BUNDLE"] = ""
-
         if imgs_per_prompt == 1:
-            score = compute_torchmetric_clip(images, texts, model_name=args.model_name)
+            score = compute_torchmetric_clip(images, texts, args.model_name, args.no_check_certificate)
         else:
             scores = []
             for i in range(imgs_per_prompt):
                 inputs = [images[i::imgs_per_prompt], texts]
-                score = compute_torchmetric_clip(*inputs, model_name=args.model_name)
+                score = compute_torchmetric_clip(*inputs, args.model_name, args.no_check_certificate)
                 scores.append(score)
             score = sum(scores) / len(scores)
 


### PR DESCRIPTION
The file `compute_torch.py` was not included in my previous commits for the clip-score PR. This is because `.gitignore` includes `*torch*.py`. I renamed the file and now `eval_clip_score.py` should work fine.