### PR TITLE
Make weight decay configurable and change default value

### DIFF
--- a/examples/stable_diffusion_v2/ldm/modules/train/optim.py
+++ b/examples/stable_diffusion_v2/ldm/modules/train/optim.py
@@ -35,7 +35,7 @@ def build_optimizer(model, opts, lr):
     other_params = list(filter(lambda x: not decay_filter(x), param_optimizer))
     group_params = []
     if len(decay_params) > 0:
-        group_params.append({"params": decay_params, "weight_decay": 1e-6})
+        group_params.append({"params": decay_params, "weight_decay": opts.weight_decay}) #1e-6})
     if len(other_params) > 0:
         group_params.append({"params": other_params, "weight_decay": 0.0})
     group_params.append({"order_params": param_optimizer})
@@ -46,5 +46,6 @@ def build_optimizer(model, opts, lr):
         OptimCls = AdamWeightDecay
     else:
         raise ValueError("invalid optimizer")
+
     optimizer = OptimCls(group_params, learning_rate=lr, beta1=opts.betas[0], beta2=opts.betas[1])
     return optimizer

--- a/examples/stable_diffusion_v2/ldm/modules/train/optim.py
+++ b/examples/stable_diffusion_v2/ldm/modules/train/optim.py
@@ -35,7 +35,7 @@ def build_optimizer(model, opts, lr):
     other_params = list(filter(lambda x: not decay_filter(x), param_optimizer))
     group_params = []
     if len(decay_params) > 0:
-        group_params.append({"params": decay_params, "weight_decay": opts.weight_decay}) #1e-6})
+        group_params.append({"params": decay_params, "weight_decay": opts.weight_decay})  # 1e-6})
     if len(other_params) > 0:
         group_params.append({"params": other_params, "weight_decay": 0.0})
     group_params.append({"order_params": param_optimizer})

--- a/examples/stable_diffusion_v2/scripts/run_train_v2.sh
+++ b/examples/stable_diffusion_v2/scripts/run_train_v2.sh
@@ -9,9 +9,9 @@ device_id=0
 
 output_path=output/finetune_pokemon
 task_name=txt2img
-data_path=./datasets/diffusion/pokemon_blip/train
+data_path=./datasets/pokemon_blip/train
 #data_path=/home/yx/datasets/diffusion/pokemon
-epochs=20
+epochs=10
 warmup_steps=1000
 
 pretrained_model_path=models/
@@ -22,6 +22,8 @@ train_batch_size=3
 use_ema=False
 ckpt_save_interval=5
 image_filter_size=200 # reduce this value if your image size is smaller than 200
+
+weight_decay=1e-2 # test
 
 # uncomment the these two lines to finetune on 768x768 resolution.
 #image_size=768 # v2-base 512, v2.1 768
@@ -47,4 +49,5 @@ python train_text_to_image.py \
     --epochs $epochs \
     --warmup_steps $warmup_steps \
     --image_filter_size=$image_filter_size \
+    --weight_decay=$weight_decay \
 #    > $output_path/$task_name/log_train_v2 2>&1 &

--- a/examples/stable_diffusion_v2/scripts/run_train_v2.sh
+++ b/examples/stable_diffusion_v2/scripts/run_train_v2.sh
@@ -11,7 +11,7 @@ output_path=output/finetune_pokemon
 task_name=txt2img
 data_path=./datasets/pokemon_blip/train
 #data_path=/home/yx/datasets/diffusion/pokemon
-epochs=10
+epochs=20
 warmup_steps=1000
 
 pretrained_model_path=models/

--- a/examples/stable_diffusion_v2/train_dreambooth.py
+++ b/examples/stable_diffusion_v2/train_dreambooth.py
@@ -212,6 +212,7 @@ def parse_args():
     parser.add_argument(
         "--betas", type=float, default=[0.9, 0.999], help="Specify the [beta1, beta2] parameter for the Adam optimizer."
     )
+    parser.add_argument("--weight_decay", default=1e-2, type=float, help="Weight decay.")
     parser.add_argument(
         "--log_level",
         type=str,

--- a/examples/stable_diffusion_v2/train_dreambooth.py
+++ b/examples/stable_diffusion_v2/train_dreambooth.py
@@ -450,6 +450,7 @@ def main(args):
                 f"LoRA rank: {args.lora_rank}",
                 f"Learning rate: {args.start_learning_rate}",
                 f"Batch size: {args.train_batch_size}",
+                f"Weight decay: {args.weight_decay}",
                 f"Grad accumulation steps: {args.gradient_accumulation_steps}",
                 f"Num epochs: {args.epochs}",
                 f"Grad clipping: {args.clip_grad}",

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -271,6 +271,7 @@ def main(args):
                 f"LoRA rank: {args.lora_rank}",
                 f"Learning rate: {args.start_learning_rate}",
                 f"Batch size: {args.train_batch_size}",
+                f"Weight decay: {args.weight_decay}",
                 f"Grad accumulation steps: {args.gradient_accumulation_steps}",
                 f"Num epochs: {args.epochs}",
                 f"Grad clipping: {args.clip_grad}",
@@ -317,6 +318,7 @@ if __name__ == "__main__":
     parser.add_argument("--lora_fp16", default=True, type=str2bool, help="Whether use fp16 for LoRA params.")
 
     parser.add_argument("--optim", default="adamw", type=str, help="optimizer")
+    parser.add_argument("--weight_decay", default=1e-6, type=float, help="Weight decay.")
     parser.add_argument("--seed", default=3407, type=int, help="data path")
     parser.add_argument("--warmup_steps", default=1000, type=int, help="warmup steps")
     parser.add_argument("--train_batch_size", default=10, type=int, help="batch size")

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -318,7 +318,7 @@ if __name__ == "__main__":
     parser.add_argument("--lora_fp16", default=True, type=str2bool, help="Whether use fp16 for LoRA params.")
 
     parser.add_argument("--optim", default="adamw", type=str, help="optimizer")
-    parser.add_argument("--weight_decay", default=1e-6, type=float, help="Weight decay.")
+    parser.add_argument("--weight_decay", default=1e-2, type=float, help="Weight decay.")
     parser.add_argument("--seed", default=3407, type=int, help="data path")
     parser.add_argument("--warmup_steps", default=1000, type=int, help="warmup steps")
     parser.add_argument("--train_batch_size", default=10, type=int, help="batch size")


### PR DESCRIPTION
- Previous bug:  
     weight decay is fixed to **1e-6**  
     The reference value used in LAION training or LoRA fine-tune in diffusers is 1e-2 

- Fix in this PR:  weight decay is now configurable via arg parser.
         Now default weight decay is  **1e-2**