### PR TITLE
Add LoRA finetuning for TextEncoder; Fix bugs

### DIFF
--- a/examples/stable_diffusion_v2/README.md
+++ b/examples/stable_diffusion_v2/README.md
@@ -67,8 +67,8 @@ Currently, we provide pre-trained stable diffusion model weights that are compat
 | 2.0-v      | text-to-image | [sd_v2_768_v-e12e3a9b.ckpt](https://download.mindspore.cn/toolkits/mindone/stable_diffusion/sd_v2_768_v-e12e3a9b.ckpt) |  [stable-diffusion-2](https://huggingface.co/stabilityai/stable-diffusion-2) | 768x768 |
 | 2.0-inpaint      | image inpainting | [sd_v2_inpaint-f694d5cf.ckpt](https://download.mindspore.cn/toolkits/mindone/stable_diffusion/sd_v2_inpaint-f694d5cf.ckpt) | [stable-diffusion-2-inpainting](https://huggingface.co/stabilityai/stable-diffusion-2-inpainting) | 512x512|
 | 1.5       | text-to-image | [sd_v1.5-d0ab7146.ckpt](https://download.mindspore.cn/toolkits/mindone/stable_diffusion/sd_v1.5-d0ab7146.ckpt) | [stable-diffusion-v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5) | 512x512 |
-| wukong    | text-to-image |  [wukong-huahua-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-ms.ckpt) |  | 512x512 |
-| wukong-inpaint    | image |  [wukong-huahua-inpaint-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-inpaint-ms.ckpt) |  | 512x512 |
+| 1.5-wukong    | text-to-image |  [wukong-huahua-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-ms.ckpt) |  | 512x512 |
+| 1.5-wukong-inpaint    | image |  [wukong-huahua-inpaint-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-inpaint-ms.ckpt) |  | 512x512 |
 
 > Resolution refers to the image resolution used in training and is also the optimal choice for image generation. Other resolutions (if only divisable by 64) are usable but may lead to a degrade in generality quality.
 <!---
@@ -255,7 +255,7 @@ python text_to_image.py --prompt "A cute wolf in winter forest" -v 1.5
 Download [wukong-huahua-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-ms.ckpt) to `models/` folder. Then run,
 
 ```
-python text_to_image.py --prompt "雪中之狼"  -v wukong
+python text_to_image.py --prompt "雪中之狼"  -v 1.5-wukong
 ```
 
 ### Chinese Text-guided Image Inpainting
@@ -263,7 +263,7 @@ python text_to_image.py --prompt "雪中之狼"  -v wukong
 Download [wukong-huahua-inpaint-ms.ckpt](https://download.mindspore.cn/toolkits/minddiffusion/wukong-huahua/wukong-huahua-inpaint-ms.ckpt) to `models/` folder. Then run,
 
 ```
-python inpaint.py --image {path to input image} --mask {path to mask image} --prompt "图片编辑内容描述"  -v wukong
+python inpaint.py --image {path to input image} --mask {path to mask image} --prompt "图片编辑内容描述"  -v 1.5-wukong
 ```
 
 ## Training

--- a/examples/stable_diffusion_v2/README.md
+++ b/examples/stable_diffusion_v2/README.md
@@ -320,7 +320,7 @@ For detailed usage of the schedulers/samplers, please refer to [Diffusion Proces
 
 # Evaluation
 
-Please refer to [Evaluation for Diffusion Models](eval/README.md)
+Please refer to [Evaluation for Diffusion Models](tools/eval/README.md)
 
 
 - - -

--- a/examples/stable_diffusion_v2/inpaint.py
+++ b/examples/stable_diffusion_v2/inpaint.py
@@ -303,8 +303,8 @@ if __name__ == "__main__":
         "--version",
         type=str,
         nargs="?",
-        default="2.0",  # "1.5_wk",
-        help="Stable diffusion version, wukong or 2.0",
+        default="2.0",
+        help="Stable diffusion version, 1.5-wukong or 2.0",
     )
 
     args = parser.parse_args()
@@ -313,12 +313,12 @@ if __name__ == "__main__":
     if args.version:
         os.environ["SD_VERSION"] = args.version
     if args.ckpt_path is None:
-        if args.version in ["wukong", "1.5_cn"]:
+        if args.version in ["1.5_cn", "1.5-wukong"]:
             args.ckpt_path = "models/wukong-huahua-inpaint-ms.ckpt"
         else:
             args.ckpt_path = "models/sd_v2_inpaint-f694d5cf.ckpt"
     if args.config is None:
-        if args.version in ["wukong", "1.5_cn"]:
+        if args.version in ["1.5_cn", "1.5-wukong"]:
             args.config = "configs/v1-inpaint-inference-chinese.yaml"
         else:
             args.config = "configs/v2-inpaint-inference.yaml"

--- a/examples/stable_diffusion_v2/ldm/modules/lora.py
+++ b/examples/stable_diffusion_v2/ldm/modules/lora.py
@@ -10,7 +10,7 @@ from mindspore.nn.cell import Cell
 from mindspore.nn.layer.activation import get_activation
 from mindspore.ops.primitive import Primitive
 
-__all__ = ["LoRADenseLayer", "LowRankDense", "inject_trainable_lora", "freeze_non_lora_params", "get_lora_params"]
+__all__ = ["LoRADenseLayer", "LowRankDense", "inject_trainable_lora", "inject_trainable_lora_to_textencoder", "freeze_non_lora_params", "get_lora_params"]
 
 _logger = logging.getLogger(__name__)
 
@@ -90,8 +90,127 @@ class LoRADenseLayer(nn.Cell):
         return h
 
 
+def inject_trainable_lora_to_textencoder(
+    net: nn.Cell, target_modules=["MultiheadAttention"], rank=4, dropout_p=0.0, scale=1.0, use_fp16=False, verbose=0
+):
+    """
+    Search target moduels and layers in the network to inject LoRA trainable parameters.
+
+    Note:
+    1. Currently only support injection to dense layers in attention modules
+    2. In order to find the target layers, currently the attention moduel must have the attribute of to_q, to_k,
+        to_v and to_out[0], each of which correpsonds to a dense layer. to_out correspnds to a SquentialCell consisting
+        of a dense layer and a dropout layer.
+    """
+    # TODO: due to qkv is not seperated, there are some difference from original impl. though num added params are the same 3 x q_dim x rank, but q, k, v lora is influencing each other.
+    target_modules = [getattr(ldm.modules.encoders.text_encoder, m) for m in target_modules]
+
+    dtype = ms.float16 if use_fp16 else ms.float32
+    ori_net_stat = {}
+    ori_net_stat["num_params"] = len(list(net.get_parameters()))
+
+    catched_attns = {}
+    injected_modules = {}
+    injected_trainable_params = {}
+
+    # 1. search target modules
+    for sc_name, subcell in net.cells_and_names():
+        if isinstance(subcell, tuple(target_modules)):
+            catched_attns[sc_name] = subcell
+            # hier_path = name.split('.')
+            # cur = net
+            # for submodule_name in hier_path:
+            #    cur = getattr(cur, submodule_name)
+
+    if verbose:
+        print("Found target modules for lora inject: ", catched_attns)
+
+    if len(catched_attns) == 0:
+        print(f"There is no target modules found in the network. Target modules {target_modules}")
+        return net
+
+    for sc_name, subcell in catched_attns.items():
+        # 2. find target layers to be injected in the module
+        # target_dense_layers = [subcell.to_q, subcell.to_k, subcell.to_v, subcell.to_out[0]]
+        target_dense_layers = [subcell.in_proj, subcell.out_proj]
+        # print(f'Target dense layers in the {sc_name}: ', target_dense_layers)
+
+        # 3. create lora dense layers
+        new_lora_dense_layers = []
+        for i, tar_dense in enumerate(target_dense_layers):
+            # print(name, tar_dense)
+            if not isinstance(tar_dense, ms.nn.Dense):
+                raise ValueError(f"{tar_dense} is NOT a nn.Dense layer")
+            has_bias = getattr(tar_dense, "has_bias")
+            in_channels = getattr(tar_dense, "in_channels")
+            out_channels = getattr(tar_dense, "out_channels")
+
+            if verbose:
+                print(f"Create LoRA dense layer, of which linear weight is {tar_dense.weight.name}.")
+            tmp_lora_dense = LoRADenseLayer(
+                in_features=in_channels, out_features=out_channels, has_bias=has_bias, rank=rank, dtype=dtype
+            )
+
+            # copy orignal weight and bias to lora linear (pointing)
+            tmp_lora_dense.linear.weight = tar_dense.weight
+            if has_bias:
+                tmp_lora_dense.linear.bias = tar_dense.bias
+
+            new_lora_dense_layers.append(tmp_lora_dense)
+
+        # 4. replace target dense layers in attention module with the created lora layers and renaming the params
+        # TODO:
+        #  instead of using fixed list, pick target dense layer by name string then replace it for better extension.
+        if verbose:
+            print("Replacing target dense layers with the created lora layers.")
+        print("D---: num tar layers: ", len(new_lora_dense_layers))
+        subcell.in_proj = new_lora_dense_layers[0]
+        subcell.out_proj = new_lora_dense_layers[1]
+
+        def _update_param_name(param, prefix_module_name):
+            if prefix_module_name not in param.name:
+                param.name = prefix_module_name + "." + param.name
+
+        for param in subcell.get_parameters():
+            if ".lora_down" in param.name or ".lora_up" in param.name or ".linear." in param.name:
+                _update_param_name(param, sc_name)
+
+                if ".lora_down" in param.name or ".lora_up" in param.name:
+                    injected_trainable_params[param.name] = param
+
+    injected_modules = catched_attns
+
+    if verbose:
+        print(
+            "Parameters in attention layers after lora injection: ",
+            "\n".join([f"{p.name}\t{p}" for p in net.get_parameters() if "_proj" in p.name]),
+        )
+        # print('=> New net after lora injection: ', net)
+        # print('\t=> Attn param names: ', '\n'.join([name+'\t'+str(param.requires_grad) for name,
+        # param in net.parameters_and_names() if '.to_' in name]))
+
+    new_net_stat = {}
+    new_net_stat["num_params"] = len(list(net.get_parameters()))
+    assert (
+        new_net_stat["num_params"] - ori_net_stat["num_params"] == len(catched_attns) * len(target_dense_layers) * 2
+    ), "Num of parameters should be increased by num_attention_layers * 2 * 2 after injection."
+    assert len(injected_trainable_params) == len(injected_modules) * 2 * 2, (
+        f"Expecting the number of injected lora trainable params to be {len(injected_modules)*2*2}, "
+        f"but got {len(injected_trainable_params)}"
+    )
+
+    _logger.info(
+        "LoRA enabled. Number of injected params: {}".format(new_net_stat["num_params"] - ori_net_stat["num_params"])
+    )
+    if verbose:
+        print("Detailed injected params: \n", "\n".join([p.name + "\t" + f"{p}" for p in injected_trainable_params]))
+
+    return injected_modules, injected_trainable_params
+
+
+
 def inject_trainable_lora(
-    net: nn.Cell, target_modules=["CrossAttention"], rank=4, dropout_p=0.0, scale=1.0, use_fp16=False, verbose=0
+    net: nn.Cell, target_modules=["CrossAttention"], rank=4, dropout_p=0.0, scale=1.0, use_fp16=False, verbose=0,
 ):
     """
     Search target moduels and layers in the network to inject LoRA trainable parameters.

--- a/examples/stable_diffusion_v2/ldm/modules/lora.py
+++ b/examples/stable_diffusion_v2/ldm/modules/lora.py
@@ -163,7 +163,6 @@ def inject_trainable_lora_to_textencoder(
         #  instead of using fixed list, pick target dense layer by name string then replace it for better extension.
         if verbose:
             print("Replacing target dense layers with the created lora layers.")
-        print("D---: num tar layers: ", len(new_lora_dense_layers))
         subcell.in_proj = new_lora_dense_layers[0]
         subcell.out_proj = new_lora_dense_layers[1]
 

--- a/examples/stable_diffusion_v2/ldm/modules/lora.py
+++ b/examples/stable_diffusion_v2/ldm/modules/lora.py
@@ -10,7 +10,14 @@ from mindspore.nn.cell import Cell
 from mindspore.nn.layer.activation import get_activation
 from mindspore.ops.primitive import Primitive
 
-__all__ = ["LoRADenseLayer", "LowRankDense", "inject_trainable_lora", "inject_trainable_lora_to_textencoder", "freeze_non_lora_params", "get_lora_params"]
+__all__ = [
+    "LoRADenseLayer",
+    "LowRankDense",
+    "inject_trainable_lora",
+    "inject_trainable_lora_to_textencoder",
+    "freeze_non_lora_params",
+    "get_lora_params",
+]
 
 _logger = logging.getLogger(__name__)
 
@@ -102,7 +109,8 @@ def inject_trainable_lora_to_textencoder(
         to_v and to_out[0], each of which correpsonds to a dense layer. to_out correspnds to a SquentialCell consisting
         of a dense layer and a dropout layer.
     """
-    # TODO: due to qkv is not seperated, there are some difference from original impl. though num added params are the same 3 x q_dim x rank, but q, k, v lora is influencing each other.
+    # TODO: due to qkv is not seperated, there are some difference from original impl.
+    # though num added params are the same 3 x q_dim x rank, but q, k, v lora is influencing each other.
     target_modules = [getattr(ldm.modules.encoders.text_encoder, m) for m in target_modules]
 
     dtype = ms.float16 if use_fp16 else ms.float32
@@ -207,9 +215,14 @@ def inject_trainable_lora_to_textencoder(
     return injected_modules, injected_trainable_params
 
 
-
 def inject_trainable_lora(
-    net: nn.Cell, target_modules=["CrossAttention"], rank=4, dropout_p=0.0, scale=1.0, use_fp16=False, verbose=0,
+    net: nn.Cell,
+    target_modules=["CrossAttention"],
+    rank=4,
+    dropout_p=0.0,
+    scale=1.0,
+    use_fp16=False,
+    verbose=0,
 ):
     """
     Search target moduels and layers in the network to inject LoRA trainable parameters.

--- a/examples/stable_diffusion_v2/lora_finetune.md
+++ b/examples/stable_diffusion_v2/lora_finetune.md
@@ -221,7 +221,7 @@ Here are the evaluation results for our implementation.
 
 - Apply LoRA to Text-encoder
 
-By default, LoRA fintuning is only applied to UNet. To finetune the text encoder with LoRA as well, please pass `--lora_ft_text_encoder=True` to the finetuning script (`train_text_to_image.py`) and inference script (`text_to_image.py`). 
+By default, LoRA fintuning is only applied to UNet. To finetune the text encoder with LoRA as well, please pass `--lora_ft_text_encoder=True` to the finetuning script (`train_text_to_image.py`) and inference script (`text_to_image.py`).
 
 
 ## Reference

--- a/examples/stable_diffusion_v2/lora_finetune.md
+++ b/examples/stable_diffusion_v2/lora_finetune.md
@@ -93,14 +93,15 @@ After training, the lora checkpoint will be saved in `{output_path}/ckpt/txt2img
 
 Below are some arguments that you may want to tune for a better performance on your dataset:
 
-- lora_rank: the rank of the low-rank matrices in lora params.
-- train_batch_size: the number of batch size for training.
-- start_learning_rate and end_learning_rate: the initial and end learning rates for training.
-- epochs: the number of epochs for training.
-- use_ema: whether use EMA for model smoothing
+- `lora_rank`: the rank of the low-rank matrices in lora params.
+- `train_batch_size`: the number of batch size for training.
+- `start_learning_rate` and `end_learning_rate`: the initial and end learning rates for training.
+- `epochs`: the number of epochs for training.
+- `use_ema`: whether use EMA for model smoothing
 > Note that the default learning rate for LoRA is 1e-4, whichis larger that vanilla finetuning (~1e-5).
 
 For more argument illustration, please run `python train_text_to_image.py -h`.
+
 
 #### Config for v-prediction (Experimental)
 
@@ -215,6 +216,12 @@ Here are the evaluation results for our implementation.
 </div>
 
 > Note that these numbers can not reflect the generation quality comprehensively!! A visual evaluation is also necessary.
+
+## Notes
+
+- Apply LoRA to Text-encoder
+
+By default, LoRA fintuning is only applied to UNet. To finetune the text encoder with LoRA as well, please pass `--lora_ft_text_encoder=True` to the finetuning script (`train_text_to_image.py`) and inference script (`text_to_image.py`). 
 
 
 ## Reference

--- a/examples/stable_diffusion_v2/scripts/run_text_to_image_v2_lora.sh
+++ b/examples/stable_diffusion_v2/scripts/run_text_to_image_v2_lora.sh
@@ -8,6 +8,7 @@ data_path=./datasets/pokemon_blip/test/prompts.txt
 #data_path=/home/yx/datasets/diffusion/pokemon/test/test_prompts.txt
 lora_ckpt_path=output/pokemon/txt2img/ckpt/rank_0/sd-72.ckpt
 output_path=output/lora_pokemon
+lora_ft_text_encoder=False # set True if finetuned text encoder as well
 
 n_samples=2
 n_iter=1
@@ -23,9 +24,10 @@ python text_to_image.py \
     --W 512 \
     --H 512 \
     --use_lora True \
+    --lora_ft_text_encoder $lora_ft_text_encoder \
     --lora_ckpt_path $lora_ckpt_path \
-    --dpm_solver \
-    --sampling_steps 15 \
+    --dpm_solver_pp \
+    --sampling_steps 20 \
     --data_path $data_path \
     #--prompt "a drawing of a flying dragon" \
     #--ckpt_path models/ \

--- a/examples/stable_diffusion_v2/scripts/run_text_to_image_v2_lora.sh
+++ b/examples/stable_diffusion_v2/scripts/run_text_to_image_v2_lora.sh
@@ -26,8 +26,8 @@ python text_to_image.py \
     --use_lora True \
     --lora_ft_text_encoder $lora_ft_text_encoder \
     --lora_ckpt_path $lora_ckpt_path \
-    --dpm_solver_pp \
-    --sampling_steps 20 \
+    --dpm_solver \
+    --sampling_steps 15 \
     --data_path $data_path \
     #--prompt "a drawing of a flying dragon" \
     #--ckpt_path models/ \

--- a/examples/stable_diffusion_v2/scripts/run_train_v2_lora.sh
+++ b/examples/stable_diffusion_v2/scripts/run_train_v2_lora.sh
@@ -51,7 +51,7 @@ python train_text_to_image.py \
     --train_batch_size=$train_batch_size \
     --epochs=$epochs \
     --use_lora=True \
-    --lora_ft_text_encoder=lora_ft_text_encoder \
+    --lora_ft_text_encoder=$lora_ft_text_encoder \
     --lora_rank=$lora_rank \
     --lora_fp16=$lora_fp16 \
     --start_learning_rate=$start_learning_rate \

--- a/examples/stable_diffusion_v2/scripts/run_train_v2_lora.sh
+++ b/examples/stable_diffusion_v2/scripts/run_train_v2_lora.sh
@@ -18,6 +18,8 @@ image_filter_size=200
 image_size=512
 train_batch_size=4
 lora_rank=128
+lora_ft_text_encoder=False # set True if finetuned text encoder as well
+
 start_learning_rate=1e-4
 end_learning_rate=0
 warmup_steps=0
@@ -49,6 +51,7 @@ python train_text_to_image.py \
     --train_batch_size=$train_batch_size \
     --epochs=$epochs \
     --use_lora=True \
+    --lora_ft_text_encoder=lora_ft_text_encoder \
     --lora_rank=$lora_rank \
     --lora_fp16=$lora_fp16 \
     --start_learning_rate=$start_learning_rate \

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -34,7 +34,7 @@ _version_cfg = {
     "2.0": ("sd_v2_base-57526ee4.ckpt", "v2-inference.yaml", 512),
     "2.0-v": ("sd_v2_768_v-e12e3a9b.ckpt", "v2-vpred-inference.yaml", 768),
     "1.5": ("sd_v1.5-d0ab7146.ckpt", "v1-inference.yaml", 512),
-    "wukong": ("wukong-huahua-ms.ckpt", "v1-inference-chinese.yaml", 512),
+    "1.5-wukong": ("wukong-huahua-ms.ckpt", "v1-inference-chinese.yaml", 512),
 }
 _URL_PREFIX = "https://download.mindspore.cn/toolkits/mindone/stable_diffusion"
 _MIN_CKPT_SIZE = 4.0 * 1e9

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -28,6 +28,7 @@ from utils.download import download_checkpoint
 
 logger = logging.getLogger("text_to_image")
 
+# naming: {sd_base_version}-{variation}
 _version_cfg = {
     "2.1": ("sd_v2-1_base-7c8d09ce.ckpt", "v2-inference.yaml", 512),
     "2.1-v": ("sd_v2-1_768_v-061732d1.ckpt", "v2-vpred-inference.yaml", 768),

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -428,7 +428,9 @@ if __name__ == "__main__":
         help="whether the checkpoint used for inference is finetuned from LoRA",
     )
     parser.add_argument("--lora_ft_unet", default=True, type=str2bool, help="whether lora finetune is applied to unet")
-    parser.add_argument("--lora_ft_text_encoder", default=False, type=str2bool, help="whether lora finetune is applied to text encoder")
+    parser.add_argument(
+        "--lora_ft_text_encoder", default=False, type=str2bool, help="whether lora finetune is applied to text encoder"
+    )
     parser.add_argument(
         "--lora_rank",
         default=None,

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -338,6 +338,7 @@ if __name__ == "__main__":
     parser.add_argument("--pretrained_model_path", default="", type=str, help="pretrained model directory")
     parser.add_argument("--pretrained_model_file", default="", type=str, help="pretrained model file name")
     parser.add_argument("--use_lora", default=False, type=str2bool, help="use lora finetuning")
+    parser.add_argument("--train_text_encoder", default=False, type=str2bool, help="whether to finetune text encoder")
     parser.add_argument(
         "--lora_rank",
         default=4,

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -181,7 +181,6 @@ def main(args):
             )
             num_injected_params += len(text_encoder_lora_params)
 
-        # TODO: support lora inject to text encoder (remove .model)
         assert (
             len(latent_diffusion_with_loss.trainable_params()) == num_injected_params
         ), "Only lora params {} should be trainable. but got {} trainable params".format(

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -165,15 +165,23 @@ def main(args):
             param.requires_grad = False
 
         # inject lora params
-        injected_attns, injected_trainable_params = inject_trainable_lora(
+        unet_lora_layers, unet_lora_params = inject_trainable_lora(
             latent_diffusion_with_loss,
             rank=args.lora_rank,
             use_fp16=args.lora_fp16,
         )
+        num_injected_parmas = len(unet_lora_params)
+        if args.train_text_encoder:
+            text_encoder_lora_layers, text_encoder_lora_params = inject_trainable_lora_to_textencoder(
+                latent_diffusion_with_loss,
+                rank=args.lora_rank,
+                use_fp16=args.lora_fp16,
+            )
+            num_injected_parmas = len(text_encoder_lora_params)
 
         # TODO: support lora inject to text encoder (remove .model)
         assert len(latent_diffusion_with_loss.trainable_params()) == len(
-            injected_trainable_params
+            num_injected_params
         ), "Only lora params should be trainable. but got {} trainable params".format(
             len(latent_diffusion_with_loss.trainable_params())
         )

--- a/examples/stable_diffusion_v2/train_text_to_image.py
+++ b/examples/stable_diffusion_v2/train_text_to_image.py
@@ -182,7 +182,10 @@ def main(args):
             num_injected_params += len(text_encoder_lora_params)
 
         # TODO: support lora inject to text encoder (remove .model)
-        assert len(latent_diffusion_with_loss.trainable_params()) == num_injected_params, "Only lora params {} should be trainable. but got {} trainable params".format(num_injected_params, len(latent_diffusion_with_loss.trainable_params())
+        assert (
+            len(latent_diffusion_with_loss.trainable_params()) == num_injected_params
+        ), "Only lora params {} should be trainable. but got {} trainable params".format(
+            num_injected_params, len(latent_diffusion_with_loss.trainable_params())
         )
         # print('Trainable params: ', latent_diffusion_with_loss.model.trainable_params())
     dataset_size = dataset.get_dataset_size()
@@ -346,7 +349,9 @@ if __name__ == "__main__":
     parser.add_argument("--pretrained_model_file", default="", type=str, help="pretrained model file name")
     parser.add_argument("--use_lora", default=False, type=str2bool, help="use lora finetuning")
     parser.add_argument("--lora_ft_unet", default=True, type=str2bool, help="whether to apply lora finetune to unet")
-    parser.add_argument("--lora_ft_text_encoder", default=False, type=str2bool, help="whether to apply lora finetune to text encoder")
+    parser.add_argument(
+        "--lora_ft_text_encoder", default=False, type=str2bool, help="whether to apply lora finetune to text encoder"
+    )
     parser.add_argument(
         "--lora_rank",
         default=4,


### PR DESCRIPTION
prev: LoRA finetune is only applied to UNet

cur: allow LoRA fine-tune both/either UNet and/or text encoder