### PR TITLE
dreambooth plus lora

### DIFF
--- a/examples/stable_diffusion_v2/dreambooth_finetune.md
+++ b/examples/stable_diffusion_v2/dreambooth_finetune.md
@@ -189,6 +189,38 @@ python train_dreambooth.py \
     --with_prior_preservation=False \
 ```
 
+#### 2.2.5 Training Command for DreamBooth with LoRA
+
+LoRA is a parameter-efficient finetuning method. Here, we combine DreamBooth with LoRA by injecting the LoRA parameters into the text encoder and the UNet of Text-to-Image model, and training with the prior preservation loss.
+
+
+In `scripts/run_train_dreambooth_w_lora_sd_v2.sh`, the training command is shown below:
+```bash
+python train_dreambooth.py \
+    --mode=0 \
+    --use_parallel=False \
+    --instance_data_dir=$instance_data_dir \
+    --instance_prompt="$instance_prompt"  \
+    --class_data_dir=$class_data_dir \
+    --class_prompt="$class_prompt" \
+    --train_config=$train_config_file \
+    --output_path=$output_path/$task_name \
+    --pretrained_model_path=$pretrained_model_path \
+    --pretrained_model_file=$pretrained_model_file \
+    --image_size=$image_size \
+    --train_batch_size=$train_batch_size \
+    --epochs=4 \
+    --start_learning_rate=5e-5 \
+    --weight_decay=1e-4  \
+    --train_text_encoder=True \
+    --use_lora=True \
+    --lora_rank=64  \
+    --lora_ft_unet=True \
+    --lora_ft_text_encoder=True  \
+```
+Note that we train the LoRA parameters with a constant learning rate `5e-5`, a weight decay `1e-4 ` for 4 epochs (800 steps). The rank of the LoRA parameter is 64.
+
+
 ### 2.3 Inference
 
 The inference command generates images on a given prompt and save them to a given output directory. An example command is as follows:
@@ -247,6 +279,29 @@ Here are the three prompts we used with class name "dog":
   <em> Figure 6. The generated images of the vanilla-finetuned model using three text prompts above. </em>
 </p>
 
+---
+
+If using LoRA with DreamBooth, the inference command should be:
+```bash
+python text_to_image.py     \
+     --prompt "a sks dog in Van Gogh painting style"   \
+     --output_path vis/output/dir  \
+     --config configs/train_dreambooth_sd_v2.yaml   \
+     --ckpt_path models/sd_v2_base-57526ee4.ckpt   \
+     --lora_ckpt_path  path/to/checkpoint/file  \
+     --use_lora True  \
+     --lora_ft_unet True  \
+     --lora_ft_text_encoder True
+```
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/wtomin/mindone-assets/main/images/sks_dog_lora_plus_dreambooth.png" width=650 />
+</p>
+<p align="center">
+  <em> Figure 7. The generated images of the model finetuned with DreamBooth and LoRA. </em>
+</p>
+
+The results in Figure 7. are very close to the results in Figure 3.
 
 ### 2.4 Evaluation
 

--- a/examples/stable_diffusion_v2/scripts/run_train_dreambooth_w_lora_sd_v2.sh
+++ b/examples/stable_diffusion_v2/scripts/run_train_dreambooth_w_lora_sd_v2.sh
@@ -1,0 +1,52 @@
+export GLOG_v=3
+export HCCL_CONNECT_TIMEOUT=600
+export ASCEND_GLOBAL_LOG_LEVEL=3
+export ASCEND_SLOG_PRINT_TO_STDOUT=0
+
+export SD_VERSION="2.0" # TODO: parse by args. or fix to 2.0 later
+
+device_id=0
+export RANK_SIZE=1
+export DEVICE_ID=$device_id
+
+output_path=output_db_w_lora/
+task_name=txt2img
+instance_data_dir=dreambooth/dataset/dog
+instance_prompt="a photo of sks dog"
+class_data_dir=temp_class_images/dog
+class_prompt="a photo of a dog"
+pretrained_model_path=models/
+pretrained_model_file=sd_v2_base-57526ee4.ckpt
+train_config_file=configs/train_dreambooth_sd_v2.json
+image_size=512
+train_batch_size=1
+# uncomment the following two lines to finetune on 768x768 resolution.
+#image_size=768 # v2-base 512, v2.1 768
+#train_batch_size=1  # 1 for 768x768, 30GB memory
+
+rm -rf ${output_path:?}/${task_name:?}
+mkdir -p ${output_path:?}/${task_name:?}
+export MS_COMPILER_CACHE_PATH=${output_path:?}/${task_name:?}; \
+
+python train_dreambooth.py \
+    --mode=0 \
+    --use_parallel=False \
+    --instance_data_dir=$instance_data_dir \
+    --instance_prompt="$instance_prompt"  \
+    --class_data_dir=$class_data_dir \
+    --class_prompt="$class_prompt" \
+    --train_config=$train_config_file \
+    --output_path=$output_path/$task_name \
+    --pretrained_model_path=$pretrained_model_path \
+    --pretrained_model_file=$pretrained_model_file \
+    --image_size=$image_size \
+    --train_batch_size=$train_batch_size \
+    --epochs=4 \
+    --start_learning_rate=5e-5 \
+    --weight_decay=1e-4  \
+    --train_text_encoder=True \
+    --use_lora=True \
+    --lora_rank=64  \
+    --lora_ft_unet=True \
+    --lora_ft_text_encoder=True  \
+#    > $output_path/$task_name/log_train_v2 2>&1 &


### PR DESCRIPTION
Train DreamBooth with LoRA:
- [x] update `train_dreambooth.py` to support `lora_ft_unet` and `lora_ft_text_encoder`;
- [x] update `dreambooth_finetune.md`, increase db+lora training / inference commands, a figure illustrating db+lora generated images.
- [x] A new shell script: `run_train_dreambooth_w_lora_sd_v2.sh`.