### PR TITLE
Videocomposer training

### DIFF
--- a/examples/videocomposer/README.md
+++ b/examples/videocomposer/README.md
@@ -57,7 +57,7 @@ To run all video generation tasks, please run
 bash run_net.sh
 ```
 
-To run a single task, you can pick the corresponding snippet of code in `run_net`.sh, such as
+To run a single task, you can pick the corresponding snippet of code in `run_net.sh`, such as
 
 ```shell
 python run_net.py\
@@ -81,15 +81,60 @@ You can adjust the arguemnts in `vc/config/base.py` (lower-priority) or `configs
 
 ## Training
 
-### Standalone Training
-To run training on a sepecifc task, please run
+### Standalone Training:
+To run training on a specific task, please refer to `run_train.sh`:
+
+```bash
+export GLOG_v=2  # Log message at or above this level. 0:INFO, 1:WARNING, 2:ERROR, 3:FATAL
+export HCCL_CONNECT_TIMEOUT=6000
+export ASCEND_GLOBAL_LOG_LEVEL=1  # Global log message level for Ascend. Setting it to 0 can slow down the process
+export ASCEND_SLOG_PRINT_TO_STDOUT=0 # 1: detail, 0: simple
+export DEVICE_ID=0  # The device id to runing training on
+
+task_name=train_exp02_motion_transfer  # the default training task
+yaml_file=configs/${task_name}.yaml
+output_path=outputs
+rm -rf ${output_path:?}/${task_name:?}
+mkdir -p ${output_path:?}/${task_name:?}
+export MS_COMPILER_CACHE_PATH=${output_path:?}/${task_name:?}
+
+nohup python -u train.py  \
+     -c $yaml_file  \
+     --output_dir $output_path/$task_name \
+    > $output_path/$task_name/train.log 2>&1 &
 
 ```
-python train.py --cfg configs/train{task_name}.yaml
+Under `configs/`, we provide several tasks' yaml files:
+```bash
+configs/
+├── train_exp02_motion_transfer_vs_style.yaml
+├── train_exp02_motion_transfer.yaml
+├── train_exp03_sketch2video_style.yaml
+├── train_exp04_sketch2video_wo_style.yaml
+├── train_exp05_text_depths_wo_style.yaml
+└── train_exp06_text_depths_vs_style.yaml
 ```
 
-E.g. `python train.py configs/train_exp02_motion_style.yaml `
+Taking `configs/train_exp02_motion_transfer.yaml` as an example, there is one critical argument:
+```yaml
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+```
+`video_compositions` defines all available conditions:
+- `text`: the text embedding.
+- `mask`: the masked video frames.
+- `depthmap`: the depth images extracted from visual frames.
+- `sketch`: the sketch images extracted from visual frames.
+- `single_sketch`: the first sketch image from `sketch`.
+- `motion`: the motion vectors extracted from the training video.
+- `image`: the image embedding used as an image style vector.
+- `local_image`: the first frame extracted from the training video.
 
+However, not all conditions are included in the training process in each of tasks above. As defined in `configs/train_exp02_motion_transfer.yaml`,
+
+```yaml
+conditions_for_train: ['text', 'local_image', 'motion']
+```
+`conditions_for_train` defines the three conditions used for training which are `['text', 'local_image', 'motion']`.
 
 ### Distributed Training
 
@@ -97,6 +142,8 @@ Please generate the hccl config file on your running server at first referring t
 ```
 rank_table_file=path/to/hccl_8p_01234567_xxx.json
 ```
+
+After that, please set `task_name` according to your target task. The default training task is `train_exp02_motion_transfer`.
 
 Then execute,
 ```

--- a/examples/videocomposer/configs/train_exp02_motion_transfer.yaml
+++ b/examples/videocomposer/configs/train_exp02_motion_transfer.yaml
@@ -1,0 +1,18 @@
+TASK_TYPE: SINGLE_TASK
+ENABLE: true
+DATASET: webvid10m
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'local_image', 'motion']  # PyTorch + Ascend setting
+vit_image_size: 224
+network_name: UNetSD_temporal
+resume: true
+seed: 182
+mvs_visual: False
+chunk_size: 16
+log_dir: 'outputs'
+learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
+epochs: 50
+
+# accelerate or memory reduction
+dataset_sink_mode: True
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/configs/train_exp02_motion_transfer_vs_style.yaml
+++ b/examples/videocomposer/configs/train_exp02_motion_transfer_vs_style.yaml
@@ -1,0 +1,18 @@
+TASK_TYPE: SINGLE_TASK
+ENABLE: true
+DATASET: webvid10m
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'image', 'local_image', 'motion']  # PyTorch + Ascend setting
+vit_image_size: 224
+network_name: UNetSD_temporal
+resume: true
+seed: 182
+mvs_visual: False
+chunk_size: 16
+log_dir: 'outputs'
+learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
+epochs: 50
+
+# accelerate or memory reduction
+dataset_sink_mode: True
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/configs/train_exp03_sketch2video_style.yaml
+++ b/examples/videocomposer/configs/train_exp03_sketch2video_style.yaml
@@ -1,0 +1,18 @@
+TASK_TYPE: SINGLE_TASK
+ENABLE: true
+DATASET: webvid10m
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'image', 'single_sketch']  # PyTorch + Ascend setting
+vit_image_size: 224
+network_name: UNetSD_temporal
+resume: true
+seed: 182
+mvs_visual: False
+chunk_size: 16
+log_dir: 'outputs'
+learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
+epochs: 50
+
+# accelerate or memory reduction
+dataset_sink_mode: True
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/configs/train_exp04_sketch2video_wo_style.yaml
+++ b/examples/videocomposer/configs/train_exp04_sketch2video_wo_style.yaml
@@ -1,0 +1,18 @@
+TASK_TYPE: SINGLE_TASK
+ENABLE: true
+DATASET: webvid10m
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'single_sketch']  # PyTorch + Ascend setting
+vit_image_size: 224
+network_name: UNetSD_temporal
+resume: true
+seed: 182
+mvs_visual: False
+chunk_size: 16
+log_dir: 'outputs'
+learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
+epochs: 50
+
+# accelerate or memory reduction
+dataset_sink_mode: True
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/configs/train_exp05_text_depths_wo_style.yaml
+++ b/examples/videocomposer/configs/train_exp05_text_depths_wo_style.yaml
@@ -1,0 +1,18 @@
+TASK_TYPE: SINGLE_TASK
+ENABLE: true
+DATASET: webvid10m
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'depthmap']  # PyTorch + Ascend setting
+vit_image_size: 224
+network_name: UNetSD_temporal
+resume: true
+seed: 182
+mvs_visual: False
+chunk_size: 16
+log_dir: 'outputs'
+learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
+epochs: 50
+
+# accelerate or memory reduction
+dataset_sink_mode: True
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/configs/train_exp06_text_depths_vs_style.yaml
+++ b/examples/videocomposer/configs/train_exp06_text_depths_vs_style.yaml
@@ -1,19 +1,18 @@
 TASK_TYPE: SINGLE_TASK
 ENABLE: true
 DATASET: webvid10m
-video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'motion', 'image', 'local_image', 'single_sketch']
-conditions_for_train: ["text", "motion", "image", "local_image"]  # PyTorch + Ascend setting
+video_compositions: ['text', 'mask', 'depthmap', 'sketch', 'single_sketch', 'motion', 'image', 'local_image']
+conditions_for_train: ['text', 'image', 'depthmap']  # PyTorch + Ascend setting
 vit_image_size: 224
 network_name: UNetSD_temporal
 resume: true
 seed: 182
 mvs_visual: False
 chunk_size: 16
-resume_checkpoint: "model_weights/non_ema_228000-7f157ec2.ckpt"
 log_dir: 'outputs'
 learning_rate: 0.00001 #0.00005 in paper, but we are finetuning.
 epochs: 50
 
 # accelerate or memory reduction
 dataset_sink_mode: True
-use_recompute: False
+use_recompute: False  # use_recompute being True scarifices speed for more memory. Set it to True if OOM

--- a/examples/videocomposer/run_train.sh
+++ b/examples/videocomposer/run_train.sh
@@ -1,10 +1,17 @@
-export GLOG_v=2
+export GLOG_v=2  # Log message at or above this level. 0:INFO, 1:WARNING, 2:ERROR, 3:FATAL
 export HCCL_CONNECT_TIMEOUT=6000
-export ASCEND_GLOBAL_LOG_LEVEL=1
-export ASCEND_SLOG_PRINT_TO_STDOUT=1 # 0 to simplify
-export DEVICE_ID=0
+export ASCEND_GLOBAL_LOG_LEVEL=1  # Global log message level for Ascend. Setting it to 0 can slow down the process
+export ASCEND_SLOG_PRINT_TO_STDOUT=0 # 1: detail, 0: simple
+export DEVICE_ID=0  # The device id to runing training on
 
-output_path='outputs/train'
+task_name=train_exp02_motion_transfer
+yaml_file=configs/${task_name}.yaml
+output_path=outputs
+rm -rf ${output_path:?}/${task_name:?}
+mkdir -p ${output_path:?}/${task_name:?}
+export MS_COMPILER_CACHE_PATH=${output_path:?}/${task_name:?}
 
-nohup python -u train.py \
-    > $output_path/train.log 2>&1 &
+nohup python -u train.py  \
+     -c $yaml_file  \
+     --output_dir $output_path/$task_name \
+    > $output_path/$task_name/train.log 2>&1 &

--- a/examples/videocomposer/run_train_distribute.sh
+++ b/examples/videocomposer/run_train_distribute.sh
@@ -1,4 +1,9 @@
-output_dir='outputs/train'
+task_name=train_exp02_motion_transfer
+yaml_file=configs/${task_name}.yaml
+output_path=outputs
+rm -rf ${output_path:?}/${task_name:?}
+mkdir -p ${output_path:?}/${task_name:?}
+export MS_COMPILER_CACHE_PATH=${output_path:?}/${task_name:?}
 
 # Parallel config
 num_devices=8
@@ -35,7 +40,8 @@ do
     mkdir -p ${output_dir:?}//rank_$i
     echo "start training for rank $RANK_ID, device $DEVICE_ID"
     nohup python -u train.py \
-        --output_dir=$output_dir \
+        --cfg=$yaml_file  \
+        --output_dir=$output_path/$task_name \
         --use_parallel=True \
-        > $output_dir/rank_$i/train.log 2>&1 &
+        > $output_path/$task_name/rank_$i/train.log 2>&1 &
 done

--- a/examples/videocomposer/vc/annotator/canny/__init__.py
+++ b/examples/videocomposer/vc/annotator/canny/__init__.py
@@ -5,13 +5,13 @@ import mindspore as ms
 
 
 class CannyDetector:
-    def __call__(self, img, low_threshold=None, high_threshold=None, random_threshold=True):
+    def __call__(self, img, low_threshold=None, high_threshold=None, random_threshold=True, return_tensor=False):
         #  Convert to numpy
         if isinstance(img, ms.Tensor):  # (h, w, c)
             img = img.asnumpy()
             img_np = cv2.convertScaleAbs((img * 255.0))
         elif isinstance(img, np.ndarray):  # (h, w, c)
-            img_np = img  # we assume values are in the range from 0 to 255.
+            img_np = cv2.convertScaleAbs((img * 255.0))
         else:
             raise TypeError(f"The input 'img' should be a 'mindspore.Tensor' or 'numpy.ndarray', but got {type(img)}.")
 
@@ -29,7 +29,9 @@ class CannyDetector:
 
         # Detect canny edge
         canny_edge = cv2.Canny(img_np, low_threshold, high_threshold)
-
-        canny_condition = ms.Tensor(canny_edge.copy()).unsqueeze(-1).float() / 255.0
+        if return_tensor:
+            canny_condition = ms.Tensor(canny_edge.copy()).unsqueeze(-1).float() / 255.0
+        else:
+            canny_condition = np.expand_dims(canny_edge, -1).astype("float32") / 255.0
 
         return canny_condition

--- a/examples/videocomposer/vc/config/parser.py
+++ b/examples/videocomposer/vc/config/parser.py
@@ -35,7 +35,7 @@ class Config(object):
             "--cfg",
             dest="cfg_file",
             help="Path to the configuration file",
-            default="configs/train.yaml",
+            default="configs/train_exp02_motion_transfer.yaml",
         )
         parser.add_argument(
             "--init_method",

--- a/examples/videocomposer/vc/utils/misc.py
+++ b/examples/videocomposer/vc/utils/misc.py
@@ -5,11 +5,21 @@ import random
 import numpy as np
 
 import mindspore as ms
+from mindspore import nn
 
 __all__ = [
     "setup_seed",
     "rand_name",
     "get_abspath_of_weights",
+    "CUSTOM_BLACK_LIST",
+]
+
+CUSTOM_BLACK_LIST = [
+    nn.BatchNorm1d,
+    nn.BatchNorm2d,
+    nn.BatchNorm3d,
+    nn.LayerNorm,
+    nn.Sigmoid,  # additional to AMP_BLACK_LIST
 ]
 
 

--- a/examples/videocomposer/vc/utils/visualization.py
+++ b/examples/videocomposer/vc/utils/visualization.py
@@ -55,10 +55,10 @@ def save_video_multiple_conditions(
     # since n=n, it equal to 2D resize/interpolate for each frame
     # TODO: this average pooling will smooth the output video too much! Can Blur the video!
     def resize_op(x, target_size):
-        if use_interpolate:
-            x = ops.interpolate(x, (n, h, w), mode="trilinear")
-        else:
-            x = ops.adaptive_avg_pool3d(x, (n, h, w))
+        try:
+            x = ops.interpolate(x, target_size, mode="trilinear")
+        except Exception:
+            x = ops.adaptive_avg_pool3d(x, target_size)
         return x
 
     source_imgs = resize_op(source_imgs, (n, h, w))


### PR DESCRIPTION
- [x] create train yaml files: one-on-one correspondence between training yaml and inference yaml;
- [x] dataset edits: additionally return `masked` (masked visual frames) ~~and `canny` (however, not used in `video_compositions` and `conditions_for_train`)~~;
- [x] readme and `run_train.sh` and `run_train_distribute.sh`: default exp is  `train_exp02_motion_transfer.yaml`;
- [x] support custom_mixed_precision mode for midas, pidinet, and cleaner.
- [x] ~~in depth/midas.py and sketch/pidinet.py, replace `ops.interpolate(xxx, mode='bilinear'`  by `ops.ResizeBilinearV2`. (On 910A, run ai core; on 910B, may run on ai core)~~. Use ops.interpolate since it leads to closer results to the torch model's results.

[result.log](https://raw.githubusercontent.com/wtomin/mindone-assets/main/videocomposer-assets/results/train_depth_results.txt) for `train_exp06_text_depth_vs_style.yaml` exp; 

Not sure if the loss is oscillating too much.