### PR TITLE
correct cfg.style_image no attribute error

### DIFF
--- a/examples/videocomposer/vc/config/parser.py
+++ b/examples/videocomposer/vc/config/parser.py
@@ -76,7 +76,7 @@ class Config(object):
         parser.add_argument(
             "--style_image",
             default="",
-            help="Single Sketch Input",
+            help="Style image input",
             type=str,
         )
         parser.add_argument(

--- a/examples/videocomposer/vc/config/parser.py
+++ b/examples/videocomposer/vc/config/parser.py
@@ -75,6 +75,7 @@ class Config(object):
         )
         parser.add_argument(
             "--style_image",
+            default="",
             help="Single Sketch Input",
             type=str,
         )


### PR DESCRIPTION
Since `vc/config/parser.py` has changed in #159 , any argument without a default value will be treated as None, which is not going to be updated in `cfg`. This can cause ` cfg.style_image no attribute error` in `vc/engine/inference_single.py`. Like `--sketch_path` an d `--image_path`, `--style_image` should have a default value.