### PR TITLE
Change some operators to fp32 calculation implicitly 

### DIFF
--- a/examples/videocomposer/vc/annotator/depth/midas.py
+++ b/examples/videocomposer/vc/annotator/depth/midas.py
@@ -20,6 +20,12 @@ _CKPT_URL = {
 # midas_v3_dpt_large-c8fd1049.ckpt is converted from midas_v3_dpt_large.pth in https://www.modelscope.cn/models/damo/VideoComposer/summary
 
 
+class LayerNorm(nn.LayerNorm):
+    def construct(self, input_x):
+        dtype = input_x.dtype
+        return super().construct(input_x.to(ms.float32)).to(dtype)
+
+
 class SelfAttention(nn.Cell):
     def __init__(self, dim, num_heads, dtype=ms.float32):
         assert dim % num_heads == 0
@@ -44,7 +50,7 @@ class SelfAttention(nn.Cell):
         # compute attention
         # ops.einsum('binc,bjnc->bnij', q, k)
         attn = self.scale * ops.bmm(q.permute(0, 2, 1, 3), k.permute(0, 2, 3, 1))
-        attn = ops.softmax(attn, axis=-1).astype(attn.dtype)
+        attn = ops.softmax(attn.to(ms.float32), axis=-1).astype(self.dtype)
 
         # gather context
         # ops.einsum('bnij,bjnc->binc', attn, v)
@@ -72,9 +78,9 @@ class AttentionBlock(nn.Cell):
         self.dtype = dtype
 
         # layers
-        self.norm1 = nn.LayerNorm((dim,)).to_float(self.dtype)
+        self.norm1 = LayerNorm((dim,))
         self.attn = SelfAttention(dim, num_heads, self.dtype)
-        self.norm2 = nn.LayerNorm((dim,)).to_float(self.dtype)
+        self.norm2 = LayerNorm((dim,))
         self.mlp = nn.SequentialCell(
             collections.OrderedDict(
                 [
@@ -139,7 +145,7 @@ class VisionTransformer(nn.Cell):
             collections.OrderedDict([(str(i), AttentionBlock(dim, num_heads, self.dtype)) for i in range(num_layers)])
         )
 
-        self.norm = nn.LayerNorm((dim,)).to_float(self.dtype)
+        self.norm = LayerNorm((dim,))
 
         # head
         self.head = nn.Dense(dim, out_dim).to_float(self.dtype)

--- a/examples/videocomposer/vc/config/base.py
+++ b/examples/videocomposer/vc/config/base.py
@@ -132,7 +132,7 @@ cfg.load_from = None
 cfg.use_checkpoint = False
 cfg.use_sharded_ddp = False
 cfg.use_fsdp = False
-cfg.use_fp16 = True  # TODO: set False for MS > 2.1, need fix
+cfg.use_fp16 = True
 
 # training
 cfg.ema_decay = 0.9999

--- a/examples/videocomposer/vc/models/unet_sd.py
+++ b/examples/videocomposer/vc/models/unet_sd.py
@@ -320,7 +320,7 @@ class ResBlock(nn.Cell):
         self.dtype = dtype
 
         self.in_layers = nn.SequentialCell(
-            GroupNorm(32, channels).to_float(ms.float32),
+            GroupNorm(32, channels),
             nn.SiLU().to_float(self.dtype),
             nn.Conv2d(channels, self.out_channels, 3, pad_mode="pad", padding=1, has_bias=True).to_float(self.dtype),
         )
@@ -344,7 +344,7 @@ class ResBlock(nn.Cell):
             ).to_float(self.dtype),
         )
         self.out_layers = nn.SequentialCell(
-            GroupNorm(32, self.out_channels).to_float(ms.float32),
+            GroupNorm(32, self.out_channels),
             nn.SiLU().to_float(self.dtype),
             nn.Dropout(1 - dropout) if is_old_ms_version() else nn.Dropout(p=dropout),
             zero_module(
@@ -1004,7 +1004,7 @@ class UNetSD_temporal(nn.Cell):
 
         # head
         self.out = nn.SequentialCell(
-            GroupNorm(32, out_dim).to_float(ms.float32),
+            GroupNorm(32, out_dim),
             nn.SiLU().to_float(self.dtype),
             nn.Conv2d(out_dim, self.out_dim, 3, pad_mode="pad", padding=1, has_bias=True).to_float(self.dtype),
         )


### PR DESCRIPTION
Change some operators to fp32 calculation implicitly instead, for preventing certain bug (e.g, `to_float` in Conv3d and GroupNorm) 