### PR TITLE
videocomposer: change relative import .. in dataset

### DIFF
--- a/examples/videocomposer/vc/data/dataset_train.py
+++ b/examples/videocomposer/vc/data/dataset_train.py
@@ -6,11 +6,11 @@ import cv2
 import numpy as np
 import pandas as pd
 from PIL import Image
+from vc.annotator.mask import make_irregular_mask, make_rectangle_mask, make_uncrop
+from vc.annotator.motion import extract_motion_vectors
 
 from mindspore import dataset as ds
 
-from ..annotator.mask import make_irregular_mask, make_rectangle_mask, make_uncrop
-from ..annotator.motion import extract_motion_vectors
 from .transforms import create_transforms
 
 __all__ = [

--- a/examples/videocomposer/vc/data/datasets.py
+++ b/examples/videocomposer/vc/data/datasets.py
@@ -6,9 +6,8 @@ import cv2
 import numpy as np
 import pandas as pd
 from PIL import Image
-
-from ..annotator.mask import make_irregular_mask, make_rectangle_mask, make_uncrop
-from ..annotator.motion import extract_motion_vectors
+from vc.annotator.mask import make_irregular_mask, make_rectangle_mask, make_uncrop
+from vc.annotator.motion import extract_motion_vectors
 
 __all__ = [
     "VideoDataset",


### PR DESCRIPTION
A minor change to avoid the error of not finding `annotator` when `export MS_COMPILER_CACHE_ENABLE=1`. This bug will be fixed in future mindspore version.