### PR TITLE
SD V2 and SD-XL: support long prompts

### DIFF
--- a/examples/stable_diffusion_v2/README.md
+++ b/examples/stable_diffusion_v2/README.md
@@ -186,6 +186,22 @@ Take SD 2.0 as an example:
 # Use SD 2.0 instead and add negative prompt guidance to eliminate artifacts
 python text_to_image.py --prompt "elven forest" -v 2.0 --negative_prompt "moss" --scale 9.0 --seed 42
 ```
+<details>
+
+  <summary>Long Prompts Support</summary>
+
+  By Default, SD V2(1.5) only supports the token sequence no longer than 77. For those sequences longer than 77, they will be truncated to 77, which can cause information loss.
+
+  To avoid information loss for long text prompts, we can divide one long tokens sequence (N>77) into several shorter sub-sequences (N<=77) to bypass the constraint of context length of the text encoders. This feature is supported by `args.support_long_prompts` in `text_to_image.py`.
+
+  When running inference with `text_to_image.py`, you can set the arguments as below.
+
+  ```bash
+  python text_to_image.py \
+  ...  \  # other arguments configurations
+  --support_long_prompts True \  # allow long text prompts
+  ```
+</details>
 
 Here are some generation results.
 

--- a/examples/stable_diffusion_v2/demo.md
+++ b/examples/stable_diffusion_v2/demo.md
@@ -40,6 +40,22 @@ Step 2. Run `text_to_image.py` to generate images for the prompt of your interes
 
 > Note: The SD2.0 checkpoint does NOT well support Chinese prompts. If you prefer to use Chinese prompts, please refer to Section 2.1.
 
+<details>
+
+  <summary>Long Prompts Support</summary>
+
+  By Default, SD V2(1.5) only supports the token sequence no longer than 77. For those sequences longer than 77, they will be truncated to 77, which can cause information loss.
+
+  To avoid information loss for long text prompts, we can divide one long tokens sequence (N>77) into several shorter sub-sequences (N<=77) to bypass the constraint of context length of the text encoders. This feature is supported by `args.support_long_prompts` in `text_to_image.py`.
+
+  When running inference with `text_to_image.py`, you can set the arguments as below.
+
+  ```bash
+  python text_to_image.py \
+  ...  \  # other arguments configurations
+  --support_long_prompts True \  # allow long text prompts
+  ```
+</details>
 
 ```shell
 # The generated images are saved in `output/samples` folder by default

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -26,7 +26,7 @@ from ldm.util import instantiate_from_config, str2bool
 from tools.safety_checker import SafetyChecker
 from utils import model_utils
 from utils.download import download_checkpoint
-from utils.long_prompt import get_long_prompts_text_embedding_function, get_long_prompts_tokenize_function
+from utils.long_prompt import get_text_embeddings
 
 logger = logging.getLogger("text_to_image")
 
@@ -119,37 +119,6 @@ def load_model_from_config(config, ckpt, use_lora=False, lora_rank=4, lora_fp16=
         param.requires_grad = False
 
     return model
-
-
-def get_text_embedding(model, prompts, negative_prompts=None, support_long_prompts=True):
-    if not support_long_prompts:
-        tokenized_prompts = model.tokenize(
-            prompts
-        )  # will truncate prompts to the context len if support_long_prompts=False
-        c = model.get_learned_conditioning(tokenized_prompts)
-        if negative_prompts is not None:
-            negative_tokenized_prompts = model.tokenize(negative_prompts)
-            uc = model.get_learned_conditioning(negative_tokenized_prompts)
-            assert c.shape == uc.shape, "text embeddings and negative text embeddings have different shapes!"
-        else:
-            uc = None
-    else:
-        tokenizer = model.cond_stage_model.tokenizer
-        context_length = model.cond_stage_model.context_length
-        tokenize_func = get_long_prompts_tokenize_function(tokenizer, context_length, pad_with_eos=False)
-        text_embedding_func = get_long_prompts_text_embedding_function(model.get_learned_conditioning)
-        group_token_ids = tokenize_func(prompts)
-        text_embeddings = text_embedding_func(group_token_ids)
-        # since in thsi script, the prompts are repetitive, the text embeddings are of the same shape which can be concatenated
-        c = ms.ops.concat([x.unsqueeze(0) for x in text_embeddings], axis=0)
-        if negative_prompts is not None:
-            negative_group_token_ids = tokenize_func(negative_prompts, force_n_groups=group_token_ids[0].shape[0])
-            text_embeddings = text_embedding_func(negative_group_token_ids)
-            uc = ms.ops.concat([x.unsqueeze(0) for x in text_embeddings], axis=0)
-            assert c.shape == uc.shape, "text embeddings and negative text embeddings have different shapes!"
-        else:
-            uc = None
-    return c, uc
 
 
 def main(args):
@@ -295,7 +264,9 @@ def main(args):
                 negative_prompts = None
             if isinstance(prompts, tuple):
                 prompts = list(prompts)
-            c, uc = get_text_embedding(model, prompts, negative_prompts, support_long_prompts=args.support_long_prompts)
+            c, uc = get_text_embeddings(
+                model, prompts, negative_prompts, support_long_prompts=args.support_long_prompts
+            )
             shape = [4, args.H // 8, args.W // 8]
             samples_ddim, _ = sampler.sample(
                 S=args.sampling_steps,

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -378,8 +378,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--support_long_prompts",
-        action="store_true",
-        help="support long prompts exceeding the context length. Otherwise, it will truncate the text prompts",
+        default=False,
+        type=str2bool,
+        help="Whether to support long prompts exceeding the context length. If False, it will truncate the text prompts",
     )
     parser.add_argument(
         "--H",

--- a/examples/stable_diffusion_v2/utils/long_prompt.py
+++ b/examples/stable_diffusion_v2/utils/long_prompt.py
@@ -1,0 +1,78 @@
+"""
+long prompt handling functions
+"""
+import mindspore as ms
+
+
+def get_long_prompts_tokenize_function(tokenizer, context_length, pad_with_eos=False):
+    """
+    The tokenizer accepts a string as the input and returns a list of tokenized ids.
+    Returns:
+        A tokenize function that handles the text prompts exceeding the context length by re-organize it into groups
+        of token ids, where each group has N = context_length.
+
+    """
+    SOT_TEXT = tokenizer.sot_text
+    EOT_TEXT = tokenizer.eot_text
+    bos, eos = tokenizer.encoder[SOT_TEXT], tokenizer.encoder[EOT_TEXT]
+
+    def get_long_prompts_token_ids(prompts, force_n_groups=None):
+        """
+        prompts, list of strings.
+        force_n_groups, Optional(int). If None, it will divide long prompts (length=N) into different chunks (N//context_len + 1).
+           If force_n_groups is provided, it will force the number of chunks equals to force_n_groups.
+        """
+        if not isinstance(prompts, (list, tuple)):
+            prompts = [prompts]
+        if force_n_groups is not None:
+            assert isinstance(force_n_groups, int) and force_n_groups >= 1, "force_n_groups should be at least 1"
+        group_ids = []
+        for prompt in prompts:
+            token_ids = tokenizer.encode(prompt)
+            new_token_ids = []
+            while len(token_ids) >= context_length - 2:
+                temp_token_ids = [bos] + [token_ids.pop(0) for _ in range(75)] + [eos]
+                new_token_ids.append(temp_token_ids)
+            # padding the left
+            if len(token_ids) > 0 or len(new_token_ids) == 0:
+                pad_token_id = eos if pad_with_eos else 0
+                pad_len = context_length - 2 - len(token_ids)
+                temp_token_ids = (
+                    [bos] + token_ids + [eos] + [pad_token_id] * pad_len
+                )  # diffuser seems to insert padding token before eos
+                new_token_ids.append(temp_token_ids)
+
+            if force_n_groups is not None:
+                if len(new_token_ids) > force_n_groups:
+                    num = len(new_token_ids) - force_n_groups
+                    for _ in range(num):
+                        new_token_ids.pop(-1)
+                elif len(new_token_ids) < force_n_groups:
+                    pad_token_id = eos if pad_with_eos else 0
+                    num = force_n_groups - len(new_token_ids)
+                    temp_token_ids = [bos] + [eos] + [pad_token_id] * (context_length - 2)
+                    for _ in range(num):
+                        new_token_ids.append(temp_token_ids)
+            new_token_ids = ms.Tensor(new_token_ids, dtype=ms.int64)
+            group_ids.append(new_token_ids)
+        return (
+            group_ids  # a list of tensors, where each tensor's shape is (n_groups, context_length). n_groups may vary
+        )
+
+    return get_long_prompts_token_ids
+
+
+def get_long_prompts_text_embedding_function(text_encoder_embedding_function):
+    def get_long_prompts_text_embedding(group_token_ids):
+        text_embeddings = []
+        if not isinstance(group_token_ids, (list, tuple)):
+            group_token_ids = [group_token_ids]
+
+        for token_ids in group_token_ids:
+            text_embed = text_encoder_embedding_function(token_ids)  # (n_groups, context_length, hidden_size)
+            text_embed = ms.ops.concat([x for x in text_embed], axis=0)  # (n_group*context_length, hidden_size)
+            text_embeddings.append(text_embed)
+
+        return text_embeddings
+
+    return get_long_prompts_text_embedding

--- a/examples/stable_diffusion_v2/utils/long_prompt.py
+++ b/examples/stable_diffusion_v2/utils/long_prompt.py
@@ -1,78 +1,212 @@
 """
 long prompt handling functions
 """
+from typing import List, Optional, Union
+
 import mindspore as ms
 
 
-def get_long_prompts_tokenize_function(tokenizer, context_length, pad_with_eos=False):
+def parse_prompt_attention(text):
+    """
+    parse a string with attention tokens and returns a list of paris: text and its associated weight
+    """
+    raise NotImplementedError
+
+
+def get_tokenize_functions(tokenizer, context_length, pad_with_eos=False):
     """
     The tokenizer accepts a string as the input and returns a list of tokenized ids.
     Returns:
-        A tokenize function that handles the text prompts exceeding the context length by re-organize it into groups
+        A tokenize function that handles the text prompts exceeding the context length by re-organize it into chunks
         of token ids, where each group has N = context_length.
-
     """
     SOT_TEXT = tokenizer.sot_text
     EOT_TEXT = tokenizer.eot_text
     bos, eos = tokenizer.encoder[SOT_TEXT], tokenizer.encoder[EOT_TEXT]
 
-    def get_long_prompts_token_ids(prompts, force_n_groups=None):
+    def get_prompt_token_ids(prompt: str):
         """
-        prompts, list of strings.
-        force_n_groups, Optional(int). If None, it will divide long prompts (length=N) into different chunks (N//context_len + 1).
-           If force_n_groups is provided, it will force the number of chunks equals to force_n_groups.
+        Args:
+            prompt, string.
+        Returns:
+            token_ids, ms.Tensor, shape is (n_chunks, context_length)
+        """
+        token_ids = tokenizer.encode(prompt)
+        new_token_ids = []
+        while len(token_ids) >= context_length - 2:
+            temp_token_ids = [bos] + [token_ids.pop(0) for _ in range(75)] + [eos]
+            new_token_ids.append(temp_token_ids)
+        # padding the left
+        if len(token_ids) > 0 or len(new_token_ids) == 0:
+            pad_token_id = eos if pad_with_eos else 0
+            pad_len = context_length - 2 - len(token_ids)
+            temp_token_ids = (
+                [bos] + token_ids + [eos] + [pad_token_id] * pad_len
+            )  # diffuser seems to insert padding token before eos
+            new_token_ids.append(temp_token_ids)
+        new_token_ids = ms.Tensor(new_token_ids, dtype=ms.int64)  # (n_chunks, context_len)
+        return new_token_ids
+
+    def get_prompt_token_ids_batch(prompts, return_tensor=True):
+        """
+        prompts, list of strings, representing a batch of strings. The length of each string may vary.
+        return_tensor, bool. If False, the returned item will be a list of tensors, where each tensor has the shape (n_chunks, context_len).
+           Note that `n_chunks` may vary.
+           If `return_tensor=True`, it will force the number of chunks equals to the maximum of n_chunks in this batch.
+           Then the returned tensor shape is (bs, max_n_chunks, context_len)
         """
         if not isinstance(prompts, (list, tuple)):
             prompts = [prompts]
-        if force_n_groups is not None:
-            assert isinstance(force_n_groups, int) and force_n_groups >= 1, "force_n_groups should be at least 1"
+
         group_ids = []
         for prompt in prompts:
-            token_ids = tokenizer.encode(prompt)
-            new_token_ids = []
-            while len(token_ids) >= context_length - 2:
-                temp_token_ids = [bos] + [token_ids.pop(0) for _ in range(75)] + [eos]
-                new_token_ids.append(temp_token_ids)
-            # padding the left
-            if len(token_ids) > 0 or len(new_token_ids) == 0:
-                pad_token_id = eos if pad_with_eos else 0
-                pad_len = context_length - 2 - len(token_ids)
-                temp_token_ids = (
-                    [bos] + token_ids + [eos] + [pad_token_id] * pad_len
-                )  # diffuser seems to insert padding token before eos
-                new_token_ids.append(temp_token_ids)
-
-            if force_n_groups is not None:
-                if len(new_token_ids) > force_n_groups:
-                    num = len(new_token_ids) - force_n_groups
-                    for _ in range(num):
-                        new_token_ids.pop(-1)
-                elif len(new_token_ids) < force_n_groups:
-                    pad_token_id = eos if pad_with_eos else 0
-                    num = force_n_groups - len(new_token_ids)
-                    temp_token_ids = [bos] + [eos] + [pad_token_id] * (context_length - 2)
-                    for _ in range(num):
-                        new_token_ids.append(temp_token_ids)
-            new_token_ids = ms.Tensor(new_token_ids, dtype=ms.int64)
+            new_token_ids = get_prompt_token_ids(prompt)
             group_ids.append(new_token_ids)
-        return (
-            group_ids  # a list of tensors, where each tensor's shape is (n_groups, context_length). n_groups may vary
-        )
 
-    return get_long_prompts_token_ids
+        if return_tensor:
+            max_len = max([x.shape[0] for x in group_ids])
+            pad_token_ids = get_prompt_token_ids("")
+            new_group_ids = []
+            for token_ids in group_ids:
+                if token_ids.shape[0] < max_len:
+                    token_ids = ms.ops.concat([token_ids] + [pad_token_ids] * (max_len - token_ids.shape[0]), axis=0)
+                new_group_ids.append(token_ids)
+            group_ids = ms.ops.stack(new_group_ids, axis=0)
+        return group_ids
+
+    return get_prompt_token_ids, get_prompt_token_ids_batch
 
 
-def get_long_prompts_text_embedding_function(text_encoder_embedding_function):
-    def get_long_prompts_text_embedding(group_token_ids):
+def get_text_embedding_functions(text_encoder_embedding_function):
+    def get_prompt_text_embedding(token_ids: ms.Tensor):
+        """
+        Args:
+            token_ids, Tensor, shape is (n, context_length)
+        """
+        return text_encoder_embedding_function(token_ids)  # (n_chunks, context_length, hidden_size)
+
+    def get_prompt_text_embedding_batch(group_token_ids, return_tensor=True):
+        """
+        Args:
+            group_token_ids, Optional[List, Tensor]. If it is a tensor, its shape is (bs, n_chunks, context_len).
+                If it is a list, it consists of `bs` tensors, and each tensor's shape is (n_chunks, context_len).
+                Note that `n_chunks` may vary.
+            return_tensor, bool. If False, the returned item will be a list of tensors, where each tensor has the shape
+                (n_chunks, context_len, hidden_size).  Note that `n_chunks` may vary.
+                If `return_tensor=True`, it will force the number of chunks equals to the maximum of n_chunks in this batch.
+                Then the returned tensor shape is (bs, max_n_chunks, context_len, hidden_size)
+        """
         text_embeddings = []
-        if not isinstance(group_token_ids, (list, tuple)):
-            group_token_ids = [group_token_ids]
-
-        for token_ids in group_token_ids:
-            text_embed = text_encoder_embedding_function(token_ids)  # (n_groups, context_length, hidden_size)
-            text_embed = ms.ops.concat([x for x in text_embed], axis=0)  # (n_group*context_length, hidden_size)
-            text_embeddings.append(text_embed)
+        if isinstance(group_token_ids, (list, tuple)):
+            # the group_token_ids is a list of tensors, where each tensor's shape is (n_chunks, context_len)
+            for token_ids in group_token_ids:
+                text_embed = get_prompt_text_embedding(token_ids)
+                text_embeddings.append(text_embed)
+            if return_tensor:
+                max_len = max([x.shape[0] for x in text_embeddings])
+                new_text_embeddings = []
+                for text_embed in text_embeddings:
+                    if text_embed.shape[0] < max_len:
+                        pad_tensor = ms.ops.zeros(
+                            (max_len - text_embed.shape[0], text_embed.shape[1], text_embed.shape[2]),
+                            dtpe=text_embed.dtype,
+                        )
+                        text_embed = ms.ops.concat([text_embed, pad_tensor], axis=0)
+                    new_text_embeddings.append(text_embed)
+                text_embeddings = ms.ops.stack(
+                    new_text_embeddings, axis=0
+                )  # (bs, max_n_chunks, context_len, hidden_size)
+        elif isinstance(group_token_ids, ms.Tensor):
+            assert (
+                len(group_token_ids.shape) == 3
+            ), f"Expect group_token_ids to have three dimensions, but got {len(group_token_ids.shape)} dims"
+            bs, n_chunks, context_len = group_token_ids.shape
+            group_token_ids = group_token_ids.reshape((bs * n_chunks, context_len))
+            text_embeddings = get_prompt_text_embedding(group_token_ids)
+            text_embeddings = text_embeddings.reshape((bs, n_chunks * context_len, -1))
+            if not return_tensor:
+                text_embeddings = [t for t in text_embeddings]
 
         return text_embeddings
 
-    return get_long_prompts_text_embedding
+    return get_prompt_text_embedding, get_prompt_text_embedding_batch
+
+
+def get_text_embeddings(
+    model,
+    prompts: Union[str, List[str]],
+    negative_prompts: Optional[Union[str, List[str]]] = None,
+    support_long_prompts: Optional[bool] = True,
+    return_tensor: Optional[bool] = True,
+):
+    """
+    Handling long text prompts and extracting text embeddings.
+    Args:
+        model: diffusion model from mindone.
+        prompts: Union[str, List[str]]. A string or a list of strings as the conditions for image generation.
+        negative_prompts: Optional[Union[str, List[str]]]. The unconditional text prompts. If provided, will
+           return the text embeddings of the negative_prompts.
+        support_long_prompts: Optional[bool]. Whether to support long prompts. If False, the token ids of each
+            long text prompt will be truncated to the context length, so that the token ids' shape will be
+            (context_len, ). If True, the token ids of each long text prompt will be divided into chunks. Thus
+            the token ids' shape will be 2d (n_chunks, context_len).
+        return_tensor: Optional[bool]. Whether to return tensor for both the token ids and the text embeddings.
+            If False, it will tolerate the case where each prompt in the batch may have different lengths. If
+            True, it will always pad the token ids or the text embeddings to the longest length in the batch.
+            It only applies when support_long_prompts is True.
+    """
+    if not isinstance(prompts, (list, tuple)):
+        prompts = [prompts]
+    if negative_prompts is not None:
+        if not isinstance(negative_prompts, (list, tuple)):
+            negative_prompts = [negative_prompts]
+        assert len(prompts) == len(
+            negative_prompts
+        ), "prompts and negative_prompts should have the same number of prompts in a batch!"
+
+    if not support_long_prompts:
+        #  will truncate prompts to the context len if support_long_prompts=False
+        tokenized_prompts = model.tokenize(prompts)
+        c = model.get_learned_conditioning(tokenized_prompts)
+        if negative_prompts is not None:
+            negative_tokenized_prompts = model.tokenize(negative_prompts)
+            uc = model.get_learned_conditioning(negative_tokenized_prompts)
+            assert c.shape == uc.shape, "text embeddings and negative text embeddings have different shapes!"
+        else:
+            uc = None
+    else:
+        tokenizer = model.cond_stage_model.tokenizer
+        context_length = model.cond_stage_model.context_length
+        tokenize_func, tokenize_func_batch = get_tokenize_functions(tokenizer, context_length, pad_with_eos=False)
+        _, text_embedding_func_batch = get_text_embedding_functions(model.get_learned_conditioning)
+        group_token_ids = tokenize_func_batch(prompts, return_tensor=return_tensor)
+        pad_token_ids = tokenize_func("")  # (1, 77)
+        if negative_prompts is not None:
+            negative_group_token_ids = tokenize_func_batch(negative_prompts, return_tensor=return_tensor)
+            # ensure that token ids of the prompts and negative prompts have the same shape
+            new_group_token_ids, new_negative_group_token_ids = [], []
+            for token_ids, negative_token_ids in zip(group_token_ids, negative_group_token_ids):
+                if token_ids.shape[0] > negative_token_ids.shape[0]:
+                    # padding with zeros
+                    num = token_ids.shape[0] - negative_token_ids.shape[0]
+                    negative_token_ids = ms.ops.concat([negative_token_ids] + [pad_token_ids] * num, axis=0)
+                elif token_ids.shape[0] < negative_token_ids.shape[0]:
+                    num = negative_token_ids.shape[0] - token_ids.shape[0]
+                    token_ids = ms.ops.concat([token_ids] + [pad_token_ids] * num, axis=0)
+                assert token_ids.shape == negative_token_ids.shape
+                new_group_token_ids.append(token_ids)
+                new_negative_group_token_ids.append(negative_token_ids)
+            group_token_ids = new_group_token_ids
+            negative_group_token_ids = new_negative_group_token_ids
+            if return_tensor:
+                group_token_ids = ms.ops.stack(group_token_ids, axis=0)
+                negative_group_token_ids = ms.ops.stack(negative_group_token_ids, axis=0)
+
+        c = text_embedding_func_batch(group_token_ids, return_tensor=return_tensor)
+        if negative_prompts is not None:
+            uc = text_embedding_func_batch(negative_group_token_ids)
+            assert c.shape == uc.shape, "text embeddings and negative text embeddings have different shapes!"
+        else:
+            uc = None
+
+    return c, uc

--- a/examples/stable_diffusion_xl/GETTING_STARTED.md
+++ b/examples/stable_diffusion_xl/GETTING_STARTED.md
@@ -194,6 +194,25 @@ python demo/sampling_without_streamlit.py \
 
 </details>
 
+<details>
+
+  <summary>Long Prompts Support</summary>
+
+  By Default, SD-XL only supports the token sequence no longer than 77. For those sequences longer than 77, they will be truncated to 77, which can cause information loss.
+
+  To avoid information loss for long text prompts, we can divide one long tokens sequence (N>77) into several shorter sub-sequences (N<=77) to bypass the constraint of context length of the text encoders. This feature is supported by `args.support_long_prompts` in `demo/sampling_without_streamlit.py`.
+
+  When running inference with `demo/sampling_without_streamlit.py`, you can set the arguments as below.
+
+  ```bash
+  python demo/sampling_without_streamlit.py \
+  ...  \  # other arguments configurations
+  --support_long_prompts True \  # allow long text prompts
+  ```
+
+
+</details>
+
 ### Offline Infer
 
 See [offline_inference](./offline_inference/README.md).

--- a/examples/stable_diffusion_xl/GETTING_STARTED.md
+++ b/examples/stable_diffusion_xl/GETTING_STARTED.md
@@ -210,6 +210,7 @@ python demo/sampling_without_streamlit.py \
   --support_long_prompts True \  # allow long text prompts
   ```
 
+When running inference with `demo/sampling.py`, you can simply input your long prompt and click the button of "Use long text prompt support (token length > 77)" under the prompt, and then start sampling.
 
 </details>
 

--- a/examples/stable_diffusion_xl/demo/sampling.py
+++ b/examples/stable_diffusion_xl/demo/sampling.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from functools import partial
 
 if os.environ.get("MS_PYNATIVE_GE") != "1":
     os.environ["MS_PYNATIVE_GE"] = "1"
@@ -21,6 +22,7 @@ from gm.helpers import (
     perform_save_locally,
 )
 from gm.util import seed_everything
+from gm.util.long_prompt import do_sample as do_sample_long_prompts
 
 import mindspore as ms
 from mindspore import Tensor, ops
@@ -60,6 +62,7 @@ def run_txt2img(
     stage2strength=None,
     amp_level="O0",
 ):
+    support_long_prompts = st.checkbox("Use long text prompt support (token length > 77)")
     W, H = st.selectbox("Resolution:", list(SD_XL_BASE_RATIOS.values()), 10)
     C = version_dict["C"]
     F = version_dict["f"]
@@ -85,7 +88,8 @@ def run_txt2img(
         outputs = st.empty()
         s_time = time.time()
 
-        out = model.do_sample(
+        sampling_func = partial(do_sample_long_prompts, model) if support_long_prompts else model.do_sample
+        out = sampling_func(
             sampler,
             value_dict,
             num_samples,

--- a/examples/stable_diffusion_xl/demo/sampling_without_streamlit.py
+++ b/examples/stable_diffusion_xl/demo/sampling_without_streamlit.py
@@ -184,6 +184,7 @@ def run_txt2img(
             return_latents=return_latents,
             filter=filter,
             amp_level=amp_level,
+            init_latent_path=args.init_latent_path,
         )
         print(f"Txt2Img sample step {sampler.num_steps}, time cost: {time.time() - s_time:.2f}s")
 

--- a/examples/stable_diffusion_xl/gm/util/long_prompt.py
+++ b/examples/stable_diffusion_xl/gm/util/long_prompt.py
@@ -1,0 +1,446 @@
+"""
+long prompt handling functions
+"""
+from typing import Dict, List, Optional
+
+import numpy as np
+from gm.helpers import get_batch, get_unique_embedder_keys_from_conditioner
+from gm.modules.embedders.open_clip.tokenizer import SimpleTokenizer
+from gm.util import expand_dims_like
+
+import mindspore as ms
+from mindspore import Tensor, ops
+
+
+def parse_prompt_attention(text):
+    """
+    parse a string with attention tokens and returns a list of paris: text and its associated weight
+    """
+    raise NotImplementedError
+
+
+def get_tokenize_functions(tokenizer, context_length, pad_with_eos=True):
+    """
+    The tokenizer accepts a string as the input and returns a list of tokenized ids.
+    Returns:
+        A tokenize function that handles the text prompts exceeding the context length by re-organize it into chunks
+        of token ids, where each group has N = context_length.
+    """
+    if tokenizer is None:
+        # use SimpleTokenizer()
+        tokenizer = SimpleTokenizer()
+        SOT_TEXT = "<start_of_text>"
+        EOT_TEXT = "<end_of_text>"
+        bos, eos = tokenizer.encoder[SOT_TEXT], tokenizer.encoder[EOT_TEXT]
+    else:
+        bos, eos = tokenizer.bos_token_id, tokenizer.eos_token_id
+
+    def get_prompt_token_ids(prompt: str):
+        """
+        Args:
+            prompt, string.
+        Returns:
+            token_ids, ms.Tensor, shape is (n_chunks, context_length)
+        """
+        if len(prompt) > 0:
+            token_ids = tokenizer.encode(prompt)
+        else:
+            token_ids = [bos, eos]  # simple tokenizer cannot handle empty string
+        if token_ids[0] == bos:
+            token_ids.pop(0)
+        if token_ids[-1] == eos:
+            token_ids.pop(-1)
+        new_token_ids = []
+        while len(token_ids) >= context_length - 2:
+            temp_token_ids = [bos] + [token_ids.pop(0) for _ in range(75)] + [eos]
+            new_token_ids.append(temp_token_ids)
+        # padding the left
+        if len(token_ids) > 0 or len(new_token_ids) == 0:
+            pad_token_id = eos if pad_with_eos else 0
+            pad_len = context_length - 2 - len(token_ids)
+            temp_token_ids = (
+                [bos] + token_ids + [eos] + [pad_token_id] * pad_len
+            )  # diffuser seems to insert padding token before eos
+            new_token_ids.append(temp_token_ids)
+        new_token_ids = ms.Tensor(new_token_ids, dtype=ms.int64)  # (n_chunks, context_len)
+        return new_token_ids
+
+    def get_prompt_token_ids_batch(prompts, return_tensor=True):
+        """
+        prompts, list of strings, representing a batch of strings. The length of each string may vary.
+        return_tensor, bool. If False, the returned item will be a list of tensors, where each tensor has the shape (n_chunks, context_len).
+           Note that `n_chunks` may vary.
+           If `return_tensor=True`, it will force the number of chunks equals to the maximum of n_chunks in this batch.
+           Then the returned tensor shape is (bs, max_n_chunks, context_len)
+        """
+        if not isinstance(prompts, (list, tuple)):
+            prompts = [prompts]
+
+        group_ids = []
+        for prompt in prompts:
+            new_token_ids = get_prompt_token_ids(prompt)
+            group_ids.append(new_token_ids)
+
+        if return_tensor:
+            max_len = max([x.shape[0] for x in group_ids])
+            pad_token_ids = get_prompt_token_ids("")
+            new_group_ids = []
+            for token_ids in group_ids:
+                if token_ids.shape[0] < max_len:
+                    token_ids = ms.ops.concat([token_ids] + [pad_token_ids] * (max_len - token_ids.shape[0]), axis=0)
+                new_group_ids.append(token_ids)
+            group_ids = ms.ops.stack(new_group_ids, axis=0)
+        return group_ids
+
+    return get_prompt_token_ids, get_prompt_token_ids_batch
+
+
+def get_text_embedding_functions(text_encoder_embedding_function):
+    def get_prompt_text_embedding(token_ids: ms.Tensor):
+        """
+        Args:
+            token_ids, Tensor, shape is (n, context_length)
+        """
+        return text_encoder_embedding_function(token_ids)  # (n_chunks, context_length, hidden_size)
+
+    def get_prompt_text_embedding_batch(group_token_ids, return_tensor=True):
+        """
+        Args:
+            group_token_ids, Optional[List, Tensor]. If it is a tensor, its shape is (bs, n_chunks, context_len).
+                If it is a list, it consists of `bs` tensors, and each tensor's shape is (n_chunks, context_len).
+                Note that `n_chunks` may vary.
+            return_tensor, bool. If False, the returned item will be a list of tensors, where each tensor has the shape
+                (n_chunks, context_len, hidden_size).  Note that `n_chunks` may vary.
+                If `return_tensor=True`, it will force the number of chunks equals to the maximum of n_chunks in this batch.
+                Then the returned tensor shape is (bs, max_n_chunks, context_len, hidden_size)
+        """
+        text_embeddings = []
+        pooled_text_embeddings = []  # a placeholder for pooled text embeddings
+        if isinstance(group_token_ids, (list, tuple)):
+            # the group_token_ids is a list of tensors, where each tensor's shape is (n_chunks, context_len)
+            for token_ids in group_token_ids:
+                text_embed = get_prompt_text_embedding(token_ids)
+                pooled_text_embedding = None
+                if isinstance(text_embed, (list, tuple)):
+                    if len(text_embed) == 2:
+                        # text embedding and pooled_text_embedding
+                        pooled_text_embedding = text_embed[1][-1]  # always take the last chunk's pooled_text_embedding
+                        text_embed = text_embed[0]
+                    else:
+                        raise ValueError(
+                            f"Expect to have one text embedding and one pooled text embedding, but got {len(text_embed)} embeddings!"
+                        )
+                text_embeddings.append(text_embed)
+                if pooled_text_embedding is not None:
+                    pooled_text_embeddings.append(pooled_text_embedding)
+
+            if return_tensor:
+                max_len = max([x.shape[0] for x in text_embeddings])
+                new_text_embeddings = []
+                for text_embed in text_embeddings:
+                    if text_embed.shape[0] < max_len:
+                        pad_tensor = ms.ops.zeros(
+                            (max_len - text_embed.shape[0], text_embed.shape[1], text_embed.shape[2]),
+                            dtpe=text_embed.dtype,
+                        )
+                        text_embed = ms.ops.concat([text_embed, pad_tensor], axis=0)
+                    new_text_embeddings.append(text_embed)
+                text_embeddings = ms.ops.stack(
+                    new_text_embeddings, axis=0
+                )  # (bs, max_n_chunks, context_len, hidden_size)
+
+        elif isinstance(group_token_ids, ms.Tensor):
+            assert (
+                len(group_token_ids.shape) == 3
+            ), f"Expect group_token_ids to have three dimensions, but got {len(group_token_ids.shape)} dims"
+            bs, n_chunks, context_len = group_token_ids.shape
+            group_token_ids = group_token_ids.reshape((bs * n_chunks, context_len))
+            text_embeddings = get_prompt_text_embedding(group_token_ids)
+            pooled_text_embeddings = None
+            if isinstance(text_embeddings, (list, tuple)):
+                if len(text_embeddings) == 2:
+                    # text embedding and pooled_text_embedding
+                    pooled_text_embeddings = text_embeddings[1]
+                    text_embeddings = text_embeddings[0]
+                else:
+                    raise ValueError(
+                        f"Expect to have one text embedding and one pooled text embedding, but got {len(text_embeddings)} embeddings!"
+                    )
+            text_embeddings = text_embeddings.reshape((bs, n_chunks * context_len, -1))
+            if pooled_text_embeddings is not None:
+                pooled_text_embeddings = pooled_text_embeddings.reshape((bs, n_chunks, -1))[
+                    :, -1
+                ]  # always take the last chunk's pooled_text_embedding
+            if not return_tensor:
+                text_embeddings = [t for t in text_embeddings]
+                pooled_text_embeddings = [t for t in pooled_text_embeddings]
+        if pooled_text_embeddings is None or len(pooled_text_embeddings) == 0:
+            return text_embeddings
+        return text_embeddings, pooled_text_embeddings
+
+    return get_prompt_text_embedding, get_prompt_text_embedding_batch
+
+
+def _force_n_chunks_token_ids(token_ids, pad_token_ids, force_n_chunks):
+    if token_ids.shape[0] < force_n_chunks:
+        num = force_n_chunks - token_ids.shape[0]
+        token_ids = ms.ops.concat([token_ids] + [pad_token_ids] * num, axis=0)
+    elif token_ids.shape[0] > force_n_chunks:
+        token_ids = token_ids[:force_n_chunks]
+    return token_ids
+
+
+def _text_embedder_tokenize_long_prompt(embedder, input_value, force_n_chunks=None, return_tensor=True):
+    tokenizer = embedder.tokenizer if hasattr(embedder, "tokenizer") else None
+    context_length = embedder.max_length
+    # pad_with_eos=True for FrozenCLIPEmbedder; pad_with_eos=False for FrozenOpenCLIPEmbedder2
+    # TODO: A better judgment term
+    pad_with_eos = hasattr(embedder, "tokenizer")
+    tokenize_func, tokenize_func_batch = get_tokenize_functions(tokenizer, context_length, pad_with_eos=pad_with_eos)
+    emb_token = tokenize_func_batch(input_value, return_tensor=return_tensor)
+    if force_n_chunks is not None:
+        pad_token_ids = tokenize_func("")
+        emb_token = [_force_n_chunks_token_ids(ids, pad_token_ids, force_n_chunks) for ids in emb_token]
+        if return_tensor:
+            emb_token = ms.ops.stack(emb_token, axis=0)
+    return emb_token
+
+
+def _embedding_group_token_ids(model, group_token_ids, force_zero_embeddings=None):
+    vector, crossattn, concat = embedding(model, *group_token_ids, force_zero_embeddings=force_zero_embeddings)
+    embeddings_dict = {}
+    for k, v in zip(("vector", "crossattn", "concat"), (vector, crossattn, concat)):
+        if v is not None:
+            embeddings_dict[k] = v
+
+    return embeddings_dict
+
+
+def tokenize(model, batch: Dict, force_n_chunks: Optional[int] = None, return_tensor: bool = True):
+    tokens = []
+    if force_n_chunks is not None:
+        assert force_n_chunks >= 1, "Expect force_n_chunks is at least one."
+    for embedder in model.embedders:
+        if hasattr(embedder, "input_key") and (embedder.input_key is not None):
+            if embedder.legacy_ucg_val is not None:
+                batch = model.possibly_get_ucg_val(embedder, batch)
+            input_value = batch[embedder.input_key]
+            # frozenclip text embedder or FrozenOpenCLIPEmbedder2
+            # TODO: a better judgemental condition
+            is_text_encoder = hasattr(embedder, "max_length")
+            if is_text_encoder:
+                emb_token = _text_embedder_tokenize_long_prompt(
+                    embedder, input_value, force_n_chunks, return_tensor=return_tensor
+                )
+            else:
+                # ConcatTimestepEmbedderND's tokenize func is an identity func
+                emb_token, _ = embedder.tokenize(input_value)
+        else:
+            raise AttributeError("embedder does not have attribute input_key/input_keys.")
+
+        assert isinstance(
+            emb_token, (Tensor, np.ndarray, list, tuple)
+        ), f"tokens must be Tensor, np.ndarray or a sequence, but got {type(emb_token)}"
+
+        tokens.append(emb_token)
+    return tokens
+
+
+def embedding(model, *tokens, force_zero_embeddings=None):
+    assert len(tokens) == len(model.embedders), (
+        f"tokens and model.embedders length is not equal, " f"{len(tokens)}, {len(model.embedders)}"
+    )
+
+    vector, crossattn, concat = None, None, None
+    if force_zero_embeddings is None:
+        force_zero_embeddings = ()
+
+    for i in range(len(model.embedders)):
+        embedder = model.embedders[i]
+        token = tokens[i]
+        token = token if isinstance(token, (list, tuple)) else (token,)
+        # TODO: a better judgemental condition
+        is_text_encoder = hasattr(embedder, "max_length")
+        if is_text_encoder:
+            _, get_text_embed_func = get_text_embedding_functions(embedder.construct)
+            emb_out = get_text_embed_func(*token, return_tensor=True)
+        else:
+            emb_out = embedder(*token)
+
+        if not isinstance(emb_out, (list, tuple)):
+            emb_out = (emb_out,)
+        for emb in emb_out:
+            if embedder.ucg_rate > 0.0 and embedder.legacy_ucg_val is None:
+                emb = (
+                    expand_dims_like(
+                        ops.bernoulli((1.0 - embedder.ucg_rate) * ops.ones(emb.shape[0], dtype=emb.dtype)),
+                        emb,
+                    )
+                    * emb
+                )
+            if hasattr(embedder, "input_key") and embedder.input_key in force_zero_embeddings:
+                emb = ops.zeros_like(emb)
+
+            # CONCAT
+            # OUTPUT_DIM2KEYS = {2: "vector", 3: "crossattn", 4: "concat", 5: "concat"}
+            # KEY2CATDIM = {"vector": 1, "crossattn": 2, "concat": 1}
+            assert emb.dim() in (2, 3, 4, 5)
+            if emb.dim() == 2:  # vector
+                if vector is None:
+                    vector = emb
+                else:
+                    vector = ops.concat((vector, emb), 1)
+            elif emb.dim() == 3:  # crossattn
+                if crossattn is None:
+                    crossattn = emb
+                else:
+                    crossattn = ops.concat((crossattn, emb), 2)
+            else:  # concat
+                if concat is None:
+                    concat = emb
+                else:
+                    concat = ops.concat((concat, emb), 1)
+
+    return vector, crossattn, concat
+
+
+def tokenize_embedding(
+    model, batch: Dict, batch_uc: Dict, force_zero_embeddings: Optional[List] = None, max_n_chunks: Optional[int] = None
+) -> Dict:
+    # tokenize
+    group_token_ids = tokenize(model, batch, return_tensor=True)
+    negative_group_token_ids = tokenize(model, batch_uc, return_tensor=True)
+    # ensure the prompts and negative prompts have the same sequence length of their token ids
+    n_chunks = group_token_ids[0].shape[1]
+    negative_n_chunks = negative_group_token_ids[0].shape[1]
+    if n_chunks > negative_n_chunks:
+        negative_group_token_ids = tokenize(model, batch_uc, force_n_chunks=n_chunks, return_tensor=True)
+    elif n_chunks < negative_n_chunks:
+        group_token_ids = tokenize(model, batch_uc, force_n_chunks=negative_n_chunks, return_tensor=True)
+
+    if max_n_chunks is not None:
+        assert max_n_chunks >= 1, "Expect that max_n_chunks should be at least one."
+        print(
+            f"The token length of long text prompts should be no longer than {max_n_chunks*group_token_ids.shape[-1]}. "
+            "Longer tokens will be truncated to this length."
+        )
+        group_token_ids = group_token_ids[:, :max_n_chunks, :]
+        negative_group_token_ids = negative_group_token_ids[:, :max_n_chunks, :]
+
+    c = _embedding_group_token_ids(model, group_token_ids)
+    uc = _embedding_group_token_ids(model, negative_group_token_ids, force_zero_embeddings)
+    return c, uc
+
+
+def get_unconditional_conditioning(
+    model,
+    batch_c,
+    batch_uc=None,
+    force_uc_zero_embeddings=None,
+    max_n_chunks: Optional[int] = None,
+):
+    if force_uc_zero_embeddings is None:
+        force_uc_zero_embeddings = []
+    ucg_rates = []
+    for embedder in model.embedders:
+        ucg_rates.append(embedder.ucg_rate)
+        embedder.ucg_rate = 0.0
+    c, uc = tokenize_embedding(
+        model, batch_c, batch_c if batch_uc is None else batch_uc, force_uc_zero_embeddings, max_n_chunks=max_n_chunks
+    )
+
+    for embedder, rate in zip(model.embedders, ucg_rates):
+        embedder.ucg_rate = rate
+    return c, uc
+
+
+def do_sample(
+    model,
+    sampler,
+    value_dict,
+    num_samples,
+    H,
+    W,
+    C,
+    F,
+    force_uc_zero_embeddings: List = None,
+    batch2model_input: List = None,
+    return_latents=False,
+    filter=None,
+    adapter_states: Optional[List[ms.Tensor]] = None,
+    amp_level="O0",
+    max_n_chunks: Optional[int] = None,
+):
+    """
+    Args:
+        reference: gm.models.diffusion.DiffusionEngine.do_sample
+        max_n_chunks: Optional[int]. If not None, the `max_n_chunks` specifies the maximum number of chunks being
+            divided from the long prompt. If None, it puts no constraints on the prompt length.
+
+    """
+    print("Sampling")
+
+    dtype = ms.float32 if amp_level not in ("O2", "O3") else ms.float16
+
+    if force_uc_zero_embeddings is None:
+        force_uc_zero_embeddings = []
+    if batch2model_input is None:
+        batch2model_input = []
+
+    num_samples = [num_samples]
+    batch, batch_uc = get_batch(
+        get_unique_embedder_keys_from_conditioner(model.conditioner), value_dict, num_samples, dtype=dtype
+    )
+    for key in batch:
+        if isinstance(batch[key], Tensor):
+            print(key, batch[key].shape)
+        elif isinstance(batch[key], list):
+            print(key, [len(i) for i in batch[key]])
+        else:
+            print(key, batch[key])
+    print("Get Condition Done.")
+
+    print("Embedding Starting (long text prompts are supported)...")
+    c, uc = get_unconditional_conditioning(
+        model.conditioner,
+        batch,
+        batch_uc=batch_uc,
+        force_uc_zero_embeddings=force_uc_zero_embeddings,
+        max_n_chunks=max_n_chunks,
+    )
+    print("Embedding Done.")
+
+    for k in c:
+        if not k == "crossattn":
+            c[k], uc[k] = map(
+                lambda y: y[k][: int(np.prod(num_samples))],
+                (c, uc)
+                # lambda y: y[k][: math.prod(num_samples)], (c, uc)
+            )
+
+    additional_model_inputs = {}
+    for k in batch2model_input:
+        additional_model_inputs[k] = batch[k]
+
+    shape = (np.prod(num_samples), C, H // F, W // F)
+    randn = Tensor(np.random.randn(*shape), ms.float32)
+
+    print("Sample latent Starting...")
+    samples_z = sampler(model, randn, cond=c, uc=uc, adapter_states=adapter_states)
+    print("Sample latent Done.")
+
+    print("Decode latent Starting...")
+    samples_x = model.decode_first_stage(samples_z)
+    samples_x = samples_x.asnumpy()
+    print("Decode latent Done.")
+
+    samples = np.clip((samples_x + 1.0) / 2.0, a_min=0.0, a_max=1.0)
+
+    if filter is not None:
+        print("Filter Starting...")
+        samples = filter(samples)
+        print("Filter Done.")
+
+    if return_latents:
+        return samples, samples_z
+    return samples


### PR DESCRIPTION
Support long prompt (without truncating the text prompts to context length) by dividing the long prompt into groups of shorter prompts.

See `args.support_long_prompts` and `utils/long_prompt.py` for details.