### PR TITLE
revert the disable first stage amp

### DIFF
--- a/examples/stable_diffusion_xl/gm/models/trainer_factory.py
+++ b/examples/stable_diffusion_xl/gm/models/trainer_factory.py
@@ -50,7 +50,10 @@ class TrainOneStepCell(nn.Cell):
 
         # first stage model
         self.scale_factor = model.scale_factor
+        disable_first_stage_amp = model.disable_first_stage_amp
         self.first_stage_model = model.first_stage_model
+        if disable_first_stage_amp:
+            self.first_stage_model.to_float(ms.float32)
 
         #
         self.sigma_sampler = model.sigma_sampler


### PR DESCRIPTION
The PR revert the deletion of the encoder float32 casting in PR #257 , which is still necessary for base model finetuning, especially when range of the encoder's intermediate calculuation result is out of bound of fp16.