### PR TITLE
SD-XL Textual Inversion: allow demo/sampling.py to use textual inversion and readme fix

### DIFF
--- a/examples/stable_diffusion_xl/demo/sampling.py
+++ b/examples/stable_diffusion_xl/demo/sampling.py
@@ -37,6 +37,7 @@ VERSION2SPECS = {
         "is_legacy": False,
         "config": "configs/inference/sd_xl_base.yaml",
         "ckpt": "checkpoints/sd_xl_base_1.0_ms.ckpt",
+        "textual_inversion_weight": None,
     },
     "SDXL-refiner-1.0": {
         "H": 1024,
@@ -46,6 +47,7 @@ VERSION2SPECS = {
         "is_legacy": True,
         "config": "configs/inference/sd_xl_refiner.yaml",
         "ckpt": "checkpoints/sd_xl_refiner_1.0_ms.ckpt",
+        "textual_inversion_weight": None,
     },
 }
 
@@ -250,6 +252,7 @@ if __name__ == "__main__":
         load_filter=False,
         param_fp16=False,
         amp_level=amp_level,
+        textual_inversion_ckpt=version_dict["textual_inversion_weight"],
     )
 
     # Get prompt
@@ -257,6 +260,10 @@ if __name__ == "__main__":
         "prompt",
         "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k",
     )
+    if version_dict["textual_inversion_weight"] is not None:
+        model, manager = model
+        # replace placeholder token by placeholder tokens
+        prompt = manager.manage_prompt(prompt)
 
     save_locally, save_path = init_save_locally(os.path.join(SAVE_PATH, mode, version))
     is_legacy = version_dict["is_legacy"]
@@ -288,6 +295,9 @@ if __name__ == "__main__":
         version_dict2 = VERSION2SPECS[version2]
 
         # Init Model
+        assert (
+            version_dict2["textual_inversion_weight"] is None
+        ), "Refiner Model does not support textual inversion now. Please do not specify `textual_inversion_weight`."
         model2, filter2 = create_model_with_streamlit(
             version_dict2["config"],
             checkpoints=version_dict2["ckpt"].split(","),
@@ -295,6 +305,7 @@ if __name__ == "__main__":
             load_filter=False,
             param_fp16=False,
             amp_level=amp_level,
+            textual_inversion_ckpt=version_dict2["textual_inversion_weight"],
         )
 
         stage2strength = st.number_input("**Refinement strength**", value=0.15, min_value=0.0, max_value=1.0)

--- a/examples/stable_diffusion_xl/textual_inversion_finetune.md
+++ b/examples/stable_diffusion_xl/textual_inversion_finetune.md
@@ -160,7 +160,7 @@ Notice that the training command above gets finetuned textual inversion weights 
   ```
 
 It is also recommended to run inference with an interactive app via streamlit. Please revise the `VERSION2SPECS` in `demo/sampling.py` as the example below (Note that `config` and `textual_inversion_weight` are modified):
-```yaml
+```python
     "SDXL-base-1.0": {
         "H": 1024,
         "W": 1024,

--- a/examples/stable_diffusion_xl/textual_inversion_finetune.md
+++ b/examples/stable_diffusion_xl/textual_inversion_finetune.md
@@ -16,10 +16,10 @@ Textual Inversion is a method to train a pretrained text-to-image model to gener
 </p>
 
 
-As shown above, the textual inversion method consists of following steps:
-- First, it creates a text prompt following some template like "A photo of $S_{*}$", where $S_{*}$ is a placeholder for the new "word" to be learned.
-- Then, the tokenizer will assign a unique index to this placeholder $S_{*}$. This index corresponds to a single embedding vector $v_{*}$ in the emebdding lookup table. Note that $v_{*}$ is trainable while all other parameters are non-trainable.
-- Lastly, compute the loss function of the generator (e.g., stable diffusion model) and the gradients of $v_{*}$. Update the weights in $v_{*}$ during training steps.
+As shown above, the textual inversion method consists of the following steps:
+1. First, it creates a text prompt following some template like **A photo of $S_{*}$**, where $S_{*}$ is a placeholder for the new "word" to be learned.
+2. Then, the tokenizer will assign a unique index to this placeholder. This index corresponds to a single embedding vector $v_{*}$ in the embedding lookup table which is trainable, while all other parameters are non-trainable.
+3. Lastly, compute the loss function of the generator (e.g., stable diffusion model) and the gradients of the single embedding vector, then update the weights in $v_{*}$ during training steps.
 
 
 ## Preparation

--- a/examples/stable_diffusion_xl/textual_inversion_finetune.md
+++ b/examples/stable_diffusion_xl/textual_inversion_finetune.md
@@ -159,6 +159,26 @@ Notice that the training command above gets finetuned textual inversion weights 
     --num_cols 4
   ```
 
+It is also recommended to run inference with an interactive app via streamlit. Please revise the `VERSION2SPECS` in `demo/sampling.py` as the example below (Note that `config` and `textual_inversion_weight` are modified):
+```yaml
+    "SDXL-base-1.0": {
+        "H": 1024,
+        "W": 1024,
+        "C": 4,
+        "f": 8,
+        "is_legacy": False,
+        "config": "configs/training/sd_xl_base_finetune_textual_inversion.yaml",
+        "ckpt": "checkpoints/sd_xl_base_1.0_ms.ckpt",
+        "textual_inversion_weight": "runs/chinese_art/SD-XL-base-1.0_2000_ti.ckpt",  # or path to another textual inversion weight
+    },
+```
+Then specify the prompt as "a dog in \<chinese-art\> style" in `__main__` of `demo/sampling.py` and run:
+
+  ```shell
+  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+  streamlit run demo/sampling.py --server.port <your_port>
+  ```
+
 ### Object Inference Results
 
 The generated images using the prompt "a \<cat-toy\> backpack" are show below:


### PR DESCRIPTION
As the title suggests, 
1. allow specifying the textual inversion weight file in ` demo/sampling.py`;
2. fix some equation expression errors in the textual inversion readme file.