### PR TITLE
Add checkpoint deletion feature to SDXL

### DIFF
--- a/examples/stable_diffusion_xl/gm/helpers.py
+++ b/examples/stable_diffusion_xl/gm/helpers.py
@@ -662,7 +662,7 @@ def delete_checkpoint(ckpt_queue, max_num_ckpt, only_save_lora):
     """
     Only keep the latest `max_num_ckpt` ckpts while training. If max_num_ckpt == 0, keep all ckpts.
     """
-    if max_num_ckpt > 0 and len(ckpt_queue) >= max_num_ckpt:
+    if max_num_ckpt is not None and len(ckpt_queue) >= max_num_ckpt:
         del_ckpt = ckpt_queue.pop(0)
         del_ckpt_lora = _build_lora_ckpt_path(del_ckpt)
         if only_save_lora:

--- a/examples/stable_diffusion_xl/gm/helpers.py
+++ b/examples/stable_diffusion_xl/gm/helpers.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import stat
 from datetime import datetime
 from typing import List, Union
 
@@ -29,8 +28,6 @@ from PIL import Image
 import mindspore as ms
 from mindspore import Tensor, context, nn, ops
 from mindspore.communication.management import get_group_size, get_rank, init
-
-_logger = logging.getLogger(__name__)
 
 
 class BroadCast(nn.Cell):
@@ -676,16 +673,17 @@ def delete_checkpoint(ckpt_queue, max_num_ckpt, only_save_lora):
         for to_del in del_ckpts:
             if os.path.isfile(to_del):
                 try:
-                    os.chmod(to_del, stat.S_IWRITE)
                     os.remove(to_del)
-                    print(
-                        f"INFO: The ckpt file {to_del} is deleted, because the number of ckpt files exceeds the limit {max_num_ckpt}."
+                    logging.debug(
+                        f"The ckpt file {to_del} is deleted, because the number of ckpt files exceeds the limit {max_num_ckpt}."
                     )
                 except OSError as e:
-                    print(e)
-                    print(f"ERROR: Failed to delete the ckpt file {to_del}.")
+                    logging.error(e)
+                    logging.error(f"Failed to delete the ckpt file {to_del}.")
             else:
-                print(f"WARNING: The ckpt file {to_del} to be deleted does not exist.")
+                logging.debug(
+                    f"The ckpt file {to_del} to be deleted doesn't exist. If lora is not used for training, it's normal that lora ckpt doesn't exist."
+                )
 
 
 def get_interactive_image(image) -> Image.Image:

--- a/examples/stable_diffusion_xl/gm/helpers.py
+++ b/examples/stable_diffusion_xl/gm/helpers.py
@@ -631,7 +631,7 @@ def perform_save_locally(save_path, samples):
 
 
 def _build_lora_ckpt_path(ckpt_path):
-    return ckpt_path[: -len(".ckpt")] + "_lora.ckpt"
+    return ckpt_path.replace(".ckpt", "_lora.ckpt")
 
 
 def save_checkpoint(model, path, ckpt_queue, max_num_ckpt, only_save_lora=False):
@@ -678,8 +678,7 @@ def delete_checkpoint(ckpt_queue, max_num_ckpt, only_save_lora):
                         f"The ckpt file {to_del} is deleted, because the number of ckpt files exceeds the limit {max_num_ckpt}."
                     )
                 except OSError as e:
-                    logging.error(e)
-                    logging.error(f"Failed to delete the ckpt file {to_del}.")
+                    logging.exception(e)
             else:
                 logging.debug(
                     f"The ckpt file {to_del} to be deleted doesn't exist. If lora is not used for training, it's normal that lora ckpt doesn't exist."

--- a/examples/stable_diffusion_xl/train.py
+++ b/examples/stable_diffusion_xl/train.py
@@ -200,7 +200,8 @@ def train(args):
         raise ValueError("args.ms_mode value must in [0, 1]")
 
     # 5. Start Training
-    assert args.max_num_ckpt is None or args.max_num_ckpt > 0, "args.max_num_ckpt must be None or a positive integer!"
+    if args.max_num_ckpt is not None and args.max_num_ckpt <= 0:
+        raise ValueError("args.max_num_ckpt must be None or a positive integer!")
     if args.task == "txt2img":
         train_fn = train_txt2img if not args.data_sink else train_txt2img_datasink
         train_fn(args, train_step_fn, dataloader=dataloader, optimizer=optimizer, model=model, jit_config=jit_config)

--- a/examples/stable_diffusion_xl/train.py
+++ b/examples/stable_diffusion_xl/train.py
@@ -55,8 +55,8 @@ def get_parser_train():
     parser.add_argument(
         "--max_num_ckpt",
         type=int,
-        default=0,
-        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set 0: keep all ckpts.",
+        default=None,
+        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set None: keep all ckpts.",
     )
     parser.add_argument("--data_sink", type=ast.literal_eval, default=False)
     parser.add_argument("--sink_size", type=int, default=1000)
@@ -200,6 +200,7 @@ def train(args):
         raise ValueError("args.ms_mode value must in [0, 1]")
 
     # 5. Start Training
+    assert args.max_num_ckpt is None or args.max_num_ckpt > 0, "args.max_num_ckpt must be None or a positive integer!"
     if args.task == "txt2img":
         train_fn = train_txt2img if not args.data_sink else train_txt2img_datasink
         train_fn(args, train_step_fn, dataloader=dataloader, optimizer=optimizer, model=model, jit_config=jit_config)

--- a/examples/stable_diffusion_xl/train.py
+++ b/examples/stable_diffusion_xl/train.py
@@ -52,6 +52,12 @@ def get_parser_train():
     parser.add_argument("--save_path_with_time", type=ast.literal_eval, default=True)
     parser.add_argument("--log_interval", type=int, default=1, help="log interval")
     parser.add_argument("--save_ckpt_interval", type=int, default=1000, help="save ckpt interval")
+    parser.add_argument(
+        "--max_num_ckpt",
+        type=int,
+        default=0,
+        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set 0: keep all ckpts.",
+    )
     parser.add_argument("--data_sink", type=ast.literal_eval, default=False)
     parser.add_argument("--sink_size", type=int, default=1000)
     parser.add_argument(
@@ -208,6 +214,8 @@ def train_txt2img(args, train_step_fn, dataloader, optimizer=None, model=None, *
     total_step = dataloader.get_dataset_size()
     loader = dataloader.create_tuple_iterator(output_numpy=True, num_epochs=1)
     s_time = time.time()
+
+    ckpt_queue = []
     for i, data in enumerate(loader):
         if not args.dataset_load_tokenizer:
             # Get data, image and tokens, to tensor
@@ -251,6 +259,8 @@ def train_txt2img(args, train_step_fn, dataloader, optimizer=None, model=None, *
                 save_checkpoint(
                     model,
                     save_ckpt_dir,
+                    ckpt_queue,
+                    args.max_num_ckpt,
                     only_save_lora=False
                     if not hasattr(model.model.diffusion_model, "only_save_lora")
                     else model.model.diffusion_model.only_save_lora,
@@ -258,6 +268,7 @@ def train_txt2img(args, train_step_fn, dataloader, optimizer=None, model=None, *
                 model.model.set_train(True)  # only unet
             else:
                 model.save_checkpoint(save_ckpt_dir)
+            ckpt_queue.append(save_ckpt_dir)
 
         # Infer during train
         if (i + 1) % args.infer_interval == 0 and args.infer_during_train:
@@ -279,6 +290,7 @@ def train_txt2img_datasink(
 
     train_fn_sink = ms.data_sink(fn=train_step_fn, dataset=dataloader, sink_size=args.sink_size, jit_config=jit_config)
 
+    ckpt_queue = []
     for epoch in range(epochs):
         cur_step = args.sink_size * (epoch + 1)
 
@@ -313,6 +325,8 @@ def train_txt2img_datasink(
                 save_checkpoint(
                     model,
                     save_ckpt_dir,
+                    ckpt_queue,
+                    args.max_num_ckpt,
                     only_save_lora=False
                     if not hasattr(model.model.diffusion_model, "only_save_lora")
                     else model.model.diffusion_model.only_save_lora,
@@ -320,6 +334,7 @@ def train_txt2img_datasink(
                 model.model.set_train(True)  # only unet
             else:
                 model.save_checkpoint(save_ckpt_dir)
+            ckpt_queue.append(save_ckpt_dir)
 
         # Infer during train
         if cur_step % args.infer_interval == 0 and args.infer_during_train:

--- a/examples/stable_diffusion_xl/train_dreambooth.py
+++ b/examples/stable_diffusion_xl/train_dreambooth.py
@@ -278,7 +278,8 @@ def train(args):
         raise ValueError("args.ms_mode value must in [0, 1]")
 
     # 5. Start Training
-    assert args.max_num_ckpt is None or args.max_num_ckpt > 0, "args.max_num_ckpt must be None or a positive integer!"
+    if args.max_num_ckpt is not None and args.max_num_ckpt <= 0:
+        raise ValueError("args.max_num_ckpt must be None or a positive integer!")
     if args.task == "txt2img":
         train_txt2img(
             args,

--- a/examples/stable_diffusion_xl/train_dreambooth.py
+++ b/examples/stable_diffusion_xl/train_dreambooth.py
@@ -65,6 +65,12 @@ def get_parser_train():
     parser.add_argument("--save_path_with_time", type=ast.literal_eval, default=True)
     parser.add_argument("--log_interval", type=int, default=1, help="log interval")
     parser.add_argument("--save_ckpt_interval", type=int, default=1000, help="save ckpt interval")
+    parser.add_argument(
+        "--max_num_ckpt",
+        type=int,
+        default=0,
+        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set 0: keep all ckpts.",
+    )
     parser.add_argument("--data_sink", type=ast.literal_eval, default=False)
     parser.add_argument("--sink_size", type=int, default=1000)
     parser.add_argument(
@@ -292,6 +298,8 @@ def train_txt2img(args, train_step_fn, dataloader, optimizer=None, model=None, *
     total_step = dataloader.get_dataset_size()
     loader = dataloader.create_tuple_iterator(output_numpy=True, num_epochs=1)
     s_time = time.time()
+
+    ckpt_queue = []
     for i, data in enumerate(loader):
         # Get data, to tensor
         if not args.dataset_load_tokenizer:
@@ -348,10 +356,13 @@ def train_txt2img(args, train_step_fn, dataloader, optimizer=None, model=None, *
             save_checkpoint(
                 model,
                 save_ckpt_dir,
+                ckpt_queue,
+                args.max_num_ckpt,
                 only_save_lora=False
                 if not hasattr(model.model.diffusion_model, "only_save_lora")
                 else model.model.diffusion_model.only_save_lora,
             )
+            ckpt_queue.append(save_ckpt_dir)
             model.model.set_train(True)
 
         # Infer during train

--- a/examples/stable_diffusion_xl/train_dreambooth.py
+++ b/examples/stable_diffusion_xl/train_dreambooth.py
@@ -68,8 +68,8 @@ def get_parser_train():
     parser.add_argument(
         "--max_num_ckpt",
         type=int,
-        default=0,
-        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set 0: keep all ckpts.",
+        default=None,
+        help="Max number of ckpts saved. If exceeds, delete the oldest one. Set None: keep all ckpts.",
     )
     parser.add_argument("--data_sink", type=ast.literal_eval, default=False)
     parser.add_argument("--sink_size", type=int, default=1000)
@@ -278,6 +278,7 @@ def train(args):
         raise ValueError("args.ms_mode value must in [0, 1]")
 
     # 5. Start Training
+    assert args.max_num_ckpt is None or args.max_num_ckpt > 0, "args.max_num_ckpt must be None or a positive integer!"
     if args.task == "txt2img":
         train_txt2img(
             args,


### PR DESCRIPTION
The sdxl ckpt files are too large (~13GB each) to save in local server especially `args.save_ckpt_interval` is set to be a small value. We can keep the latest `args.max_num_ckpt` ckpt files and delete those old ones. Keep all ckpts when `args.max_num_ckpt` is 0.