### PR TITLE
FlashAttention: fix compatibility

### DIFF
--- a/examples/stable_diffusion_v2/ldm/modules/attention.py
+++ b/examples/stable_diffusion_v2/ldm/modules/attention.py
@@ -184,7 +184,7 @@ class CrossAttention(nn.Cell):
                 # logger.info("Flash attention is enabled.")
             else:
                 self.flash_attention = FlashAttention()
-                self.fa_mask_dtype = ms.uint8
+                self.fa_mask_dtype = ms.float16
         else:
             self.flash_attention = None
 
@@ -232,17 +232,11 @@ class CrossAttention(nn.Cell):
             q = q.view(q_b, q_n, h, -1).transpose(0, 2, 1, 3)
             k = k.view(k_b, k_n, h, -1).transpose(0, 2, 1, 3)
             v = v.view(v_b, v_n, h, -1).transpose(0, 2, 1, 3)
-            if new_version():
-                if mask is None:
-                    mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
-                out = self.flash_attention(
-                    q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
-                )
-            else:
-                if mask is None:
-                    mask = ops.zeros((q_b, q_n, q_n), q.dtype)
-                out = self.flash_attention(q, k, v, mask)
-
+            if mask is None:
+                mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
+            out = self.flash_attention(
+                q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
+            )
             b, h, n, d = out.shape
             # reshape FA output to original attn input format, (b h n d) -> (b n h*d)
             out = out.transpose(0, 2, 1, 3).view(b, n, -1)
@@ -319,17 +313,11 @@ class CrossFrameAttention(CrossAttention):
             q = q.view(q_b, q_n, h, -1).transpose(0, 2, 1, 3)
             k = k.view(k_b, k_n, h, -1).transpose(0, 2, 1, 3)
             v = v.view(v_b, v_n, h, -1).transpose(0, 2, 1, 3)
-            if new_version():
-                if mask is None:
-                    mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
-                out = self.flash_attention(
-                    q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
-                )
-            else:
-                if mask is None:
-                    mask = ops.zeros((q_b, q_n, q_n), q.dtype)
-                out = self.flash_attention(q, k, v, mask)
-
+            if mask is None:
+                mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
+            out = self.flash_attention(
+                q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
+            )
             b, h, n, d = out.shape
             # reshape FA output to original attn input format, (b h n d) -> (b n h*d)
             out = out.transpose(0, 2, 1, 3).view(b, n, -1)

--- a/examples/stable_diffusion_v2/ldm/modules/attention.py
+++ b/examples/stable_diffusion_v2/ldm/modules/attention.py
@@ -232,14 +232,16 @@ class CrossAttention(nn.Cell):
             q = q.view(q_b, q_n, h, -1).transpose(0, 2, 1, 3)
             k = k.view(k_b, k_n, h, -1).transpose(0, 2, 1, 3)
             v = v.view(v_b, v_n, h, -1).transpose(0, 2, 1, 3)
-            if mask is None:
-                mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
             if new_version():
+                if mask is None:
+                    mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
                 out = self.flash_attention(
                     q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
                 )
             else:
-                out = self.flash_attention(q, k, v, mask.to(q.dtype))
+                if mask is None:
+                    mask = ops.zeros((q_b, q_n, q_n), q.dtype)
+                out = self.flash_attention(q, k, v, mask)
 
             b, h, n, d = out.shape
             # reshape FA output to original attn input format, (b h n d) -> (b n h*d)
@@ -317,15 +319,16 @@ class CrossFrameAttention(CrossAttention):
             q = q.view(q_b, q_n, h, -1).transpose(0, 2, 1, 3)
             k = k.view(k_b, k_n, h, -1).transpose(0, 2, 1, 3)
             v = v.view(v_b, v_n, h, -1).transpose(0, 2, 1, 3)
-            if mask is None:
-                mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
-
             if new_version():
+                if mask is None:
+                    mask = ops.zeros((q_b, q_n, q_n), self.fa_mask_dtype)
                 out = self.flash_attention(
                     q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
                 )
             else:
-                out = self.flash_attention(q, k, v, mask.to(q.dtype))
+                if mask is None:
+                    mask = ops.zeros((q_b, q_n, q_n), q.dtype)
+                out = self.flash_attention(q, k, v, mask)
 
             b, h, n, d = out.shape
             # reshape FA output to original attn input format, (b h n d) -> (b n h*d)


### PR DESCRIPTION
After the modifications, I have run `text_to_image.py` on both 910A(ms2.1) and 910B(ms2.2) with SDv1.5 and SDv2.0. All the experiments worked without errors, and the generated images are of good quality.

However, the experiments only related to `CrossAttention`. I haven't tested with `CrossFrameAttention`, because I'm not sure when `CrossFrameAttention` is applied.

**PS**: I just found that SDv1.5 does not use flash-attention by default. Therefore the experiments with SDv1.5 were not meaningful.