### PR TITLE
FlashAttention: Fix Compatibility 

### DIFF
--- a/examples/stable_diffusion_v2/ldm/modules/attention.py
+++ b/examples/stable_diffusion_v2/ldm/modules/attention.py
@@ -16,14 +16,6 @@ import logging
 
 import numpy as np
 from ldm.util import is_old_ms_version
-
-# import os
-# import sys
-# # TODO: remove in future when mindone is ready for install
-# __dir__ = os.path.dirname(os.path.abspath(__file__))
-# mindone_lib_path = os.path.abspath(os.path.join(__dir__, "../../../../"))
-# sys.path.insert(0, mindone_lib_path)
-# from mindone.utils.version_control import is_910a
 from packaging import version
 
 import mindspore as ms


### PR DESCRIPTION
Another solution to fix the compatibility problem of flash-attention layer. It might be a better solution compared with #291  because using `nn.layers.flash_attention` supports head_dim that is not divisible by 16 by padding it to 16*N.

I have tested `text_to_image.py` on:
1. 910A (ms2.1.0)
1.1 sdv2.0 
 :heavy_check_mark: graph mode
 :heavy_check_mark: pynative mode
1.2 sdv1.5
 :heavy_check_mark: graph mode
 :heavy_check_mark: pynative mode
**sdv1.5 succeed because I restrict the `fa_max_head_dim` to 128 instead of 256 on 910A, otherwise there will be OOM error; This value can be passed through `v1-inference.yaml`**.

2 910B (ms 2.2.10.2023.1124)
2.1 sdv1.5
 :heavy_check_mark: graph mode
 :heavy_check_mark: pynative mode
2.2  sdv2.0 
 :heavy_check_mark: graph mode
:x:  pynative mode
```
out = self.flash_attention(
    q.to(ms.float16), k.to(ms.float16), v.to(ms.float16), mask.to(self.fa_mask_dtype)
)
...
Runtime Error: Index 3 is out of bounds 3.
```
I think it is a weird bug, because graph mode has no such an error.