### PR TITLE
improve data pipeline by adding MindData native support

### DIFF
--- a/examples/stable_diffusion_v2/ldm/data/dataset_refactored.py
+++ b/examples/stable_diffusion_v2/ldm/data/dataset_refactored.py
@@ -1,0 +1,73 @@
+import logging
+from pathlib import Path
+from typing import Callable, List
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+from mindspore.dataset.vision import CenterCrop, RandomCrop, RandomHorizontalFlip, Resize
+
+from mindone.data import BaseDataset
+
+_logger = logging.getLogger(__name__)
+
+
+class ImageDataset(BaseDataset):
+    def __init__(self, data_path: str, image_filter_size: int = 0, drop_text_prob: float = 0.0):
+        self._data = self._read_data(Path(data_path))
+        self._drop_text_prob = drop_text_prob
+        self._filter_images(image_filter_size)
+
+        self.output_columns = ["image", "caption"]
+
+    @staticmethod
+    def _read_data(data_path: Path):
+        annos = data_path.glob("*.csv")
+        combined_df = pd.concat([pd.read_csv(anno) for anno in annos])
+        combined_df["dir"] = combined_df.apply(lambda row: data_path / row["dir"], axis=1)
+        data = combined_df.rename(columns={"dir": "image", "text": "caption"}).to_dict("records")
+        return data
+
+    def _filter_images(self, filter_size: int = 0):
+        old_len = len(self._data)
+        # Use multithreading to speed up reading image sizes?
+        self._data = [
+            item for item in self._data if item["image"].exists() and min(Image.open(item["image"]).size) >= filter_size
+        ]
+        if len(self._data) < old_len:
+            _logger.info(
+                f"Filtered out {old_len - len(self._data)} images as they are either too small or do not exist"
+            )
+
+    def __getitem__(self, idx):
+        image = Image.open(self._data[idx]["image"])
+        if not image.mode == "RGB":
+            image = image.convert("RGB")
+        image = np.array(image)
+        caption = self._data[idx]["caption"] if np.random.rand() >= self._drop_text_prob else ""
+        return image, caption
+
+    def __len__(self):
+        return len(self._data)
+
+    @staticmethod
+    def train_transforms(
+        target_size: int, tokenizer: Callable[[str], np.ndarray], random_crop: bool = False
+    ) -> List[dict]:
+        transforms = [
+            {
+                "operations": [
+                    Resize(target_size),
+                    RandomCrop(target_size) if random_crop else CenterCrop(target_size),
+                    RandomHorizontalFlip(prob=0.5),
+                ],
+                "input_columns": ["image"],
+            },
+            {  # keep python transforms separate from C++ for speed
+                "operations": [lambda x: (x / 127.5 - 1.0).astype(np.float32)],
+                "input_columns": ["image"],
+            },
+            {"operations": tokenizer, "input_columns": ["caption"]},
+        ]
+        return transforms

--- a/examples/t2i_adapter/configs/sd_v2.1_train.yaml
+++ b/examples/t2i_adapter/configs/sd_v2.1_train.yaml
@@ -10,7 +10,7 @@ train:
   output_dir: output/t2i_adapter_v2.1/
 
   dataset:
-    class_path: examples.stable_diffusion_v2.ldm.data.dataset_with_cond.COCOStuff
+    class_path: data.dataset_with_cond.COCOStuff
     init_args:
       image_dir:
       masks_path:

--- a/mindone/data/__init__.py
+++ b/mindone/data/__init__.py
@@ -1,0 +1,2 @@
+from .dataset import BaseDataset
+from .loader import build_dataloader

--- a/mindone/data/dataset.py
+++ b/mindone/data/dataset.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class BaseDataset(ABC):
+    """
+    An abstract base class for datasets in MindONE package.
+
+    Required attributes:
+        output_columns: A list of column names that a dataset is expected to output.
+    """
+
+    output_columns: List[str]
+
+    @abstractmethod
+    def __getitem__(self, idx):
+        ...
+
+    @abstractmethod
+    def __len__(self):
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def train_transforms(**kwargs) -> List[dict]:
+        """
+        Defines a list transformations that should be applied to the training data in the following form:
+
+        {
+            "operations": [List of transform operations],               # Required
+            "input_columns": [List of columns to apply transforms to],  # Optional
+            "output_columns": [List of output columns]                  # Optional, only used if different from the `input columns`
+        }
+
+        Args:
+            **kwargs: additional parameters to be passed to the transformations.
+
+        Returns:
+            A list of transformations that should be applied to the training data.
+
+        Examples:
+            >>> import numpy as np
+            >>> from mindspore.dataset.vision import Resize, ToTensor
+            >>>
+            >>> def train_transforms(tokenizer) -> List[dict]:
+            >>>     transforms = [
+            >>>         {
+            >>>             "operations": tokenizer,
+            >>>             "input_columns": ["caption"],
+            >>>         },
+            >>>         {
+            >>>             "operations": [Resize((512, 512)), lambda x: (x / 127.5 - 1.0).astype(np.float32)],
+            >>>             "input_columns": ["image"],
+            >>>         },
+            >>>         {
+            >>>             "operations": [Resize((512, 512)), ToTensor()],
+            >>>             "input_columns": ["condition"],
+            >>>         },
+            >>>     ]
+            >>>
+            >>>     return transforms
+        """
+        ...

--- a/mindone/data/loader.py
+++ b/mindone/data/loader.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Union
 
 import mindspore as ms
 from mindspore.communication import get_local_rank, get_local_rank_size

--- a/mindone/data/loader.py
+++ b/mindone/data/loader.py
@@ -7,7 +7,7 @@ from .dataset import BaseDataset
 
 
 def build_dataloader(
-    dataset: Type[BaseDataset],
+    dataset: BaseDataset,
     batch_size: int,
     transforms: Optional[Union[List[dict], dict]] = None,
     shuffle: bool = False,

--- a/mindone/data/loader.py
+++ b/mindone/data/loader.py
@@ -55,6 +55,9 @@ def build_dataloader(
     Returns:
         ms.dataset.BatchDataset: The DataLoader for the given dataset.
     """
+    if not hasattr(dataset, "output_columns"):
+        raise AttributeError(f"{type(dataset).__name__} must have `output_columns` attribute.")
+
     ms.dataset.config.set_prefetch_size(prefetch_size)
     ms.dataset.config.set_enable_shared_mem(True)
     ms.dataset.config.set_debug_mode(debug)

--- a/mindone/data/loader.py
+++ b/mindone/data/loader.py
@@ -1,11 +1,13 @@
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Type, Union
 
 import mindspore as ms
-from mindspore.communication.management import get_local_rank, get_local_rank_size
+from mindspore.communication import get_local_rank, get_local_rank_size
+
+from .dataset import BaseDataset
 
 
 def build_dataloader(
-    dataset: Any,
+    dataset: Type[BaseDataset],
     batch_size: int,
     transforms: Optional[Union[List[dict], dict]] = None,
     shuffle: bool = False,
@@ -28,23 +30,23 @@ def build_dataloader(
         dataset: A dataset instance, must have `output_columns` member.
         batch_size: Number of samples per batch.
         transforms: Optional transformations to apply to the dataset. It can be a list of transform dictionaries or
-        a single transform dictionary. The dictionary must have the following structure:
-        {
-            "operations": [List of transform operations],               # Required
-            "input_columns": [List of columns to apply transforms to],  # Optional
-            "output_columns": [List of output columns]                  # Optional, only used if different from input columns
-        }
+                    a single transform dictionary. The dictionary must have the following structure:
+                    {
+                        "operations": [List of transform operations],               # Required
+                        "input_columns": [List of columns to apply transforms to],  # Optional
+                        "output_columns": [List of output columns]                  # Optional, only used if different from the `input columns`
+                    }
         shuffle: Whether to randomly sample data. Default is False.
         num_workers: The number of workers used for data transformations. Default is 4.
         num_workers_dataset: The number of workers used for reading data from the dataset. Default is 4.
         num_workers_batch: The number of workers used for batch aggregation. Default is 2.
         drop_remainder: Whether to drop the remainder of the dataset if it doesn't divide evenly by `batch_size`.
-            Default is True.
+                        Default is True.
         python_multiprocessing: Whether to use Python multiprocessing for data transformations. This option could be
-        beneficial if the Python operation is computational heavy. Default is True.
+                                beneficial if the Python operation is computational heavy. Default is True.
         prefetch_size: The number of samples to prefetch (per device). Default is 16.
         max_rowsize: Maximum size of row in MB that is used for shared memory allocation to copy data between processes.
-        This is only used if `python_multiprocessing` is set to `True`. Default is 64.
+                     This is only used if `python_multiprocessing` is set to `True`. Default is 64.
         device_num: The number of devices to distribute the dataset across. Default is 1.
         rank_id: The rank ID of the current device. Default is 0.
         debug: Whether to enable debug mode. Default is False.


### PR DESCRIPTION
This PR introduces native support for the MindData pipeline, building upon our successful experiments in the MindOCR project (https://github.com/mindspore-lab/mindocr/pull/416). Our experiments showed that this pipeline not only simplifies the development process through modularization but also improves training speed by **up to 3 times**.

However, as the native pipeline integration occurred during the late stages of MindOCR development, the process was quite challenging, and the PR has not yet been merged. To prevent similar problems in MindONE, I strongly recommend adopting the new pipeline as early as possible.

**The idea is as follows:** each dataset in MindONE should inherit from the `BaseDataset` class, define the required attribute `output_columns`, and implement the abstract methods. This includes `train_transforms`, which is used later in `build_dataloader` to map transformations to the training data.