### PR TITLE
SD V1.5: disable Flash-attention by default

### DIFF
--- a/examples/stable_diffusion_v2/README.md
+++ b/examples/stable_diffusion_v2/README.md
@@ -218,7 +218,23 @@ python text_to_image.py --prompt "elven forest" -v 2.0 --negative_prompt "moss" 
   ```
 </details>
 
+<details>
 
+  <summary>Flash-Attention Support</summary>
+
+  MindONE supports flash attention by setting the argument `enable_flash_attention` as `True` in `configs/v1-inference.yaml` or `configs/v2-inference.yaml`. For example, in `configs/v1-inference.yaml`:
+
+  ```
+      unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        ...
+        enable_flash_attention: False
+        fa_max_head_dim: 256  # max head dim of flash attention. In case of oom, reduce it to 128
+  ```
+  One can set `enable_flash_attention` to `True`. In case of OOM (out of memory) error, please reduce the `fa_max_head_dim` to 128.
+
+</details>
 
 Here are some generation results.
 

--- a/examples/stable_diffusion_v2/configs/v1-inference.yaml
+++ b/examples/stable_diffusion_v2/configs/v1-inference.yaml
@@ -30,7 +30,7 @@ model:
         channel_mult: [ 1, 2, 4, 4 ]
         num_heads: 8 # num of attention head, => head dim will be 320 / 8 = 40, not divisable by 16
         use_spatial_transformer: True
-        enable_flash_attention: True
+        enable_flash_attention: False
         fa_max_head_dim: 256  # max head dim of flash attention. In case of oom, reduce it to 128
         transformer_depth: 1
         context_dim: 768


### PR DESCRIPTION
Because of the risk of oom on 910A of sdv1.5+ FA, we should change the default setting and leave the option to the user.