### PR TITLE
fix unclip inference and add ddim v-pred support

### DIFF
--- a/examples/stable_diffusion_v2/configs/v2-vpred-inference-unclip-h.yaml
+++ b/examples/stable_diffusion_v2/configs/v2-vpred-inference-unclip-h.yaml
@@ -19,6 +19,7 @@ model:
     scale_factor: 0.18215
     use_ema: False
     use_fp16: True
+    parameterization: "velocity"
 
     embedder_config:
       target: ldm.modules.encoders.modules.FrozenOpenCLIPImageEmbedder

--- a/examples/stable_diffusion_v2/configs/v2-vpred-inference-unclip-l.yaml
+++ b/examples/stable_diffusion_v2/configs/v2-vpred-inference-unclip-l.yaml
@@ -19,6 +19,7 @@ model:
     scale_factor: 0.18215
     use_ema: False
     use_fp16: True
+    parameterization: "velocity"
 
     embedder_config:
       target: ldm.modules.encoders.modules.CLIPImageEmbedder

--- a/examples/stable_diffusion_v2/configs/v2-vpred-inference.yaml
+++ b/examples/stable_diffusion_v2/configs/v2-vpred-inference.yaml
@@ -18,6 +18,7 @@ model:
     scale_factor: 0.18215
     use_ema: False
     use_fp16: True
+    parameterization: "velocity"
 
     unet_config:
       target: ldm.modules.diffusionmodules.openaimodel.UNetModel

--- a/examples/stable_diffusion_v2/ldm/models/diffusion/ddim.py
+++ b/examples/stable_diffusion_v2/ldm/models/diffusion/ddim.py
@@ -303,7 +303,7 @@ class DDIMSampler(object):
             )
             model_output = model_uncond + unconditional_guidance_scale * (model_t - model_uncond)
 
-        if self.model.parameterization == "v":
+        if self.model.parameterization == "velocity":
             e_t = self.model.predict_eps_from_z_and_v(x, t, model_output)
         else:
             e_t = model_output
@@ -325,7 +325,7 @@ class DDIMSampler(object):
         sqrt_one_minus_at = ms.numpy.full((b, 1, 1, 1), sqrt_one_minus_alphas[index])
 
         # current prediction for x_0
-        if self.model.parameterization != "v":
+        if self.model.parameterization != "velocity":
             pred_x0 = (x - sqrt_one_minus_at * e_t) / a_t.sqrt()
         else:
             pred_x0 = self.model.predict_start_from_z_and_v(x, t, model_output)

--- a/examples/stable_diffusion_v2/ldm/models/diffusion/ddpm.py
+++ b/examples/stable_diffusion_v2/ldm/models/diffusion/ddpm.py
@@ -241,6 +241,18 @@ class DDPM(nn.Cell):
             + extract_into_tensor(self.sqrt_one_minus_alphas_cumprod, t, x_start.shape) * noise
         )
 
+    def predict_start_from_z_and_v(self, x_t, t, v):
+        return (
+            extract_into_tensor(self.sqrt_alphas_cumprod, t, x_t.shape) * x_t
+            - extract_into_tensor(self.sqrt_one_minus_alphas_cumprod, t, x_t.shape) * v
+        )
+
+    def predict_eps_from_z_and_v(self, x_t, t, v):
+        return (
+            extract_into_tensor(self.sqrt_alphas_cumprod, t, x_t.shape) * v
+            + extract_into_tensor(self.sqrt_one_minus_alphas_cumprod, t, x_t.shape) * x_t
+        )
+
 
 class LatentDiffusion(DDPM):
     def __init__(

--- a/examples/stable_diffusion_v2/ldm/modules/encoders/modules.py
+++ b/examples/stable_diffusion_v2/ldm/modules/encoders/modules.py
@@ -195,6 +195,7 @@ class FrozenOpenCLIPEmbedder(FrozenCLIPEmbedder):
         self.dtype = ms.float16 if use_fp16 else ms.float32
         self.context_length = context_length
         self.tokenizer = get_tokenizer(tokenizer_name)
+        self.tokenizer_name = tokenizer_name
         setattr(self.tokenizer, "context_length", context_length)
 
         self.model = OpenClipTextEncoder(

--- a/examples/stable_diffusion_v2/text_to_image.py
+++ b/examples/stable_diffusion_v2/text_to_image.py
@@ -228,9 +228,10 @@ def main(args):
         sname = "dpm_solver_pp"
     if prediction_type == "v":
         assert sname in [
+            "ddim",
             "dpm_solver",
             "dpm_solver_pp",
-        ], "Only dpm_solver and dpm_solver_pp support v-prediction currently."
+        ], "Only ddim, dpm_solver and dpm_solver_pp support v-prediction currently."
 
     # create safety checker
     if args.check_safety:

--- a/examples/stable_diffusion_v2/unclip_image_variation.py
+++ b/examples/stable_diffusion_v2/unclip_image_variation.py
@@ -17,6 +17,7 @@ import mindspore.ops as ops
 
 workspace = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(workspace)
+from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 from ldm.modules.logger import set_logger
 from ldm.modules.lora import inject_trainable_lora
@@ -216,9 +217,15 @@ def main(args):
     logger.info(f"Prediction type: {prediction_type}")
 
     # create sampler
-    # TODO: currently we support DPM only
-    sampler = DPMSolverSampler(model, "dpmsolver", prediction_type=prediction_type)
-    sname = "dpm_solver"
+    if args.ddim:
+        sampler = DDIMSampler(model)
+        sname = "ddim"
+    elif args.dpm_solver:
+        sampler = DPMSolverSampler(model, "dpmsolver", prediction_type=prediction_type)
+        sname = "dpm_solver"
+    else:
+        sampler = DPMSolverSampler(model, "dpmsolver++", prediction_type=prediction_type)
+        sname = "dpm_solver_pp"
 
     # log
     key_info = "Key Settings:\n" + "=" * 50 + "\n"
@@ -389,6 +396,16 @@ if __name__ == "__main__":
         type=int,
         default=768,
         help="image width, in pixel space",
+    )
+    parser.add_argument(
+        "--ddim",
+        action="store_true",
+        help="use ddim sampling",
+    )
+    parser.add_argument(
+        "--dpm_solver",
+        action="store_true",
+        help="use dpm_solver sampling",
     )
     parser.add_argument(
         "--scale",


### PR DESCRIPTION
- Fix the unclip inference on 910/910* due to recent PRs changes
- Add DDIM v-pred support for text-to-image and unclip-image-variation, since DDIM is usually served as a benchmark for result comparison. 