### PR TITLE
Fix bug when ms.set_context(max_device_memory="xxGB")

### DIFF
--- a/examples/animatediff/tools/embedding_cache.py
+++ b/examples/animatediff/tools/embedding_cache.py
@@ -112,6 +112,9 @@ def init_env(
     """
     set_random_seed(seed)
 
+    if max_device_memory is not None:
+        ms.set_context(max_device_memory=max_device_memory)
+
     device_num = 1
     device_id = int(os.getenv("DEVICE_ID", 0))
     rank_id = 0
@@ -121,9 +124,6 @@ def init_env(
         device_id=device_id,
         # ascend_config={"precision_mode": "allow_fp32_to_fp16"},  # TODO: tune
     )
-
-    if max_device_memory is not None:
-        ms.set_context(max_device_memory=max_device_memory)
 
     return device_id, rank_id, device_num
 

--- a/examples/animatediff/train.py
+++ b/examples/animatediff/train.py
@@ -132,6 +132,9 @@ def init_env(
     """
     set_random_seed(seed)
 
+    if max_device_memory is not None:
+        ms.set_context(max_device_memory=max_device_memory)
+
     if distributed:
         device_id = int(os.getenv("DEVICE_ID"))
         ms.set_context(
@@ -164,9 +167,6 @@ def init_env(
             device_id=device_id,
             ascend_config={"precision_mode": "allow_fp32_to_fp16"},  # TODO: tune
         )
-
-    if max_device_memory is not None:
-        ms.set_context(max_device_memory=max_device_memory)
 
     return device_id, rank_id, device_num
 

--- a/examples/dit/train.py
+++ b/examples/dit/train.py
@@ -66,6 +66,9 @@ def init_env(
     """
     set_random_seed(seed)
 
+    if max_device_memory is not None:
+        ms.set_context(max_device_memory=max_device_memory)
+
     if distributed:
         device_id = int(os.getenv("DEVICE_ID"))
         ms.set_context(
@@ -98,9 +101,6 @@ def init_env(
             device_id=device_id,
             # ascend_config={"precision_mode": "allow_fp32_to_fp16"},  # TODO: tune
         )
-
-    if max_device_memory is not None:
-        ms.set_context(max_device_memory=max_device_memory)
 
     return device_id, rank_id, device_num
 

--- a/examples/stable_diffusion_v2/train_dreambooth.py
+++ b/examples/stable_diffusion_v2/train_dreambooth.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def init_env(args):
     set_random_seed(args.seed)
-    ms.set_context(max_device_memory="30GB")  # TODO: why limit?
+    ms.set_context(max_device_memory=args.max_device_memory)  # TODO: why limit?
     ms.set_context(mode=args.mode)  # needed for MS2.0
     if args.use_parallel:
         init()
@@ -87,6 +87,7 @@ def parse_args():
     parser.add_argument("--dataset_sink_mode", default=False, type=str2bool, help="sink mode")
     parser.add_argument("--mode", default=0, type=int, help="Specify the mode: 0 for graph mode, 1 for pynative mode")
     parser.add_argument("--use_parallel", default=False, type=str2bool, help="Enable parallel processing")
+    parser.add_argument("--max_device_memory", type=str, default="30GB", help="e.g. `30GB` for 910a, `59GB` for 910b")
     parser.add_argument("--use_lora", default=False, type=str2bool, help="Enable LoRA finetuning")
     parser.add_argument("--lora_ft_unet", default=False, type=str2bool, help="whether to apply lora finetune to unet")
     parser.add_argument(

--- a/examples/stable_diffusion_v2/train_dreambooth.py
+++ b/examples/stable_diffusion_v2/train_dreambooth.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 def init_env(args):
     set_random_seed(args.seed)
+    ms.set_context(max_device_memory="30GB")  # TODO: why limit?
     ms.set_context(mode=args.mode)  # needed for MS2.0
     if args.use_parallel:
         init()
@@ -59,7 +60,6 @@ def init_env(args):
         mode=args.mode,
         device_target="Ascend",
         device_id=device_id,
-        max_device_memory="30GB",  # TODO: why limit?
         pynative_synchronize=False,  # for debug in pynative mode
     )
 

--- a/examples/videocomposer/analyze_video_frames.py
+++ b/examples/videocomposer/analyze_video_frames.py
@@ -29,6 +29,7 @@ def init_env(args):
     # rank_id - global card id, device_num - num of cards
     set_random_seed(args.seed)
 
+    # ms.set_context(max_device_memory="30GB")  # adapt for 910b
     ms.set_context(mode=args.ms_mode)  # needed for MS2.0
     if args.use_parallel:
         init()
@@ -54,7 +55,6 @@ def init_env(args):
         mode=args.ms_mode,
         device_target="Ascend",
         device_id=device_id,
-        # max_device_memory="30GB", # adapt for 910b
     )
     ms.set_context(ascend_config={"precision_mode": "allow_fp32_to_fp16"})  # Only effective on Ascend 901B
 

--- a/examples/videocomposer/analyze_video_meta.py
+++ b/examples/videocomposer/analyze_video_meta.py
@@ -196,6 +196,7 @@ def init_env(args):
     # rank_id - global card id, device_num - num of cards
     set_random_seed(args.seed)
 
+    # ms.set_context(max_device_memory="30GB")  # adapt for 910b
     ms.set_context(mode=args.ms_mode)  # needed for MS2.0
     if args.use_parallel:
         init()
@@ -221,7 +222,6 @@ def init_env(args):
         mode=args.ms_mode,
         device_target="Ascend",
         device_id=device_id,
-        # max_device_memory="30GB", # adapt for 910b
     )
     ms.set_context(ascend_config={"precision_mode": "allow_fp32_to_fp16"})  # Only effective on Ascend 901B
 

--- a/examples/videocomposer/train.py
+++ b/examples/videocomposer/train.py
@@ -47,6 +47,7 @@ def init_env(args):
     # rank_id - global card id, device_num - num of cards
     set_random_seed(args.seed)
 
+    # ms.set_context(max_device_memory="30GB")  # adapt for 910b
     ms.set_context(mode=args.ms_mode)  # needed for MS2.0
     if args.use_parallel:
         init()
@@ -72,7 +73,6 @@ def init_env(args):
         mode=args.ms_mode,
         device_target="Ascend",
         device_id=device_id,
-        # max_device_memory="30GB", # adapt for 910b
     )
     ms.set_context(ascend_config={"precision_mode": "allow_fp32_to_fp16"})  # Only effective on Ascend 901B
     # ms.set_context(ascend_config={"precision_mode": "allow_fp32_to_bf16"})  # TODO: testing bf16


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
MindSpore context [`max_device_memory`](https://www.mindspore.cn/docs/zh-CN/master/api_python/mindspore/mindspore.set_context.html#mindspore.set_context) can NOT be set after [`init()`](https://www.mindspore.cn/docs/zh-CN/master/api_python/mindspore.communication.html) while running in distributed mode. Otherwise error below raises:

```
Traceback (most recent call last):
  File "/home/ma-user/modelarts/user-job-dir/mindone/examples/animatediff/train.py", line 510, in <module>
    main(args)
  File "/home/ma-user/modelarts/user-job-dir/mindone/examples/animatediff/train.py", line 188, in main
    max_device_memory=args.max_device_memory,
  File "/home/ma-user/modelarts/user-job-dir/mindone/examples/animatediff/train.py", line 173, in init_env
    ms.set_context(max_device_memory=max_device_memory)
  File "/home/ma-user/anaconda3/envs/ms_animatediff/lib/python3.7/site-packages/mindspore/_checkparam.py", line 1313, in wrapper
    return func(*args, **kwargs)
  File "/home/ma-user/anaconda3/envs/ms_animatediff/lib/python3.7/site-packages/mindspore/context.py", line 1493, in set_context
    ctx.setters[key](ctx, value)
  File "/home/ma-user/anaconda3/envs/ms_animatediff/lib/python3.7/site-packages/mindspore/context.py", line 472, in set_max_device_memory
    self.set_param(ms_ctx_param.max_device_memory, max_device_memory_value)
  File "/home/ma-user/anaconda3/envs/ms_animatediff/lib/python3.7/site-packages/mindspore/context.py", line 175, in set_param
    self._context_handle.set_param(param, value)
TypeError: For 'set_context', the parameter max_device_memory can not be set repeatedly, origin value [1024] has been in effect.

----------------------------------------------------
- C++ Call Stack: (For framework developers)
----------------------------------------------------
mindspore/core/utils/ms_context.cc:477 CheckReadStatus
```

