### PR TITLE
SDXL: transpose `text_projection` in converting

### DIFF
--- a/examples/stable_diffusion_xl/tools/model_conversion/convert_diffusers_to_mindone_sdxl.py
+++ b/examples/stable_diffusion_xl/tools/model_conversion/convert_diffusers_to_mindone_sdxl.py
@@ -304,7 +304,9 @@ def convert_weight(state_dict, msname):
         kt, kms = key_torch[i], key_ms[i]
         vms = Tensor(state_dict["state_dict"][kt].numpy(), ms.float32)
         if "conditioner.embedders.1.model.text_projection" == kms:
-            print(f"[Attention] {kms} is called differently in MindONE and Diffusers, so it is transposed in converting")
+            print(
+                f"[Attention] {kms} is called differently in MindONE and Diffusers, so it is transposed in converting"
+            )
             vms = ms.ops.transpose(vms, (1, 0))
         newckpt.append({"name": kms, "data": vms})
         ms_key.append(kms)

--- a/examples/stable_diffusion_xl/tools/model_conversion/convert_diffusers_to_mindone_sdxl.py
+++ b/examples/stable_diffusion_xl/tools/model_conversion/convert_diffusers_to_mindone_sdxl.py
@@ -302,7 +302,11 @@ def convert_weight(state_dict, msname):
     ms_key = []
     for i in range(len(key_torch)):
         kt, kms = key_torch[i], key_ms[i]
-        newckpt.append({"name": kms, "data": Tensor(state_dict["state_dict"][kt].numpy(), ms.float32)})
+        vms = Tensor(state_dict["state_dict"][kt].numpy(), ms.float32)
+        if "conditioner.embedders.1.model.text_projection" == kms:
+            print(f"[Attention] {kms} is called differently in MindONE and Diffusers, so it is transposed in converting")
+            vms = ms.ops.transpose(vms, (1, 0))
+        newckpt.append({"name": kms, "data": vms})
         ms_key.append(kms)
     ms.save_checkpoint(newckpt, msname)
     print("convert Stable Diffusion checkpoint(torch) to MindOne Stable Diffusion checkpoint(mindspore) success!")
@@ -404,7 +408,7 @@ if __name__ == "__main__":
 
     if osp.exists(args.unet_path):
         if args.unet_path.endswith(".bin"):
-            unet_state_dict = torch.load(args.unet_bin_path, map_location="cpu")
+            unet_state_dict = torch.load(args.unet_path, map_location="cpu")
         else:
             unet_state_dict = load_file(args.unet_path, device="cpu")
         print("load unet from unet_path: ", args.unet_path)

--- a/examples/stable_diffusion_xl/tools/model_conversion/convert_weight.py
+++ b/examples/stable_diffusion_xl/tools/model_conversion/convert_weight.py
@@ -1,10 +1,8 @@
 import argparse
 
 import torch
-from safetensors.torch import (
-    load_file as load_safetensors,
-    save_file as save_safetensors,
-)
+from safetensors.torch import load_file as load_safetensors
+from safetensors.torch import save_file as save_safetensors
 
 import mindspore as ms
 from mindspore import Tensor

--- a/examples/stable_diffusion_xl/tools/model_conversion/convert_weight.py
+++ b/examples/stable_diffusion_xl/tools/model_conversion/convert_weight.py
@@ -1,7 +1,10 @@
 import argparse
 
 import torch
-from safetensors.torch import load_file as load_safetensors
+from safetensors.torch import (
+    load_file as load_safetensors,
+    save_file as save_safetensors,
+)
 
 import mindspore as ms
 from mindspore import Tensor
@@ -54,7 +57,7 @@ def ms_to_pt(args):
         assert k_ms in sd, f"Keys '{k_ms}' not found in {args.key_ms}"
         new_ckpt[k_t] = torch.from_numpy(sd[k_ms].data.asnumpy())
 
-    torch.save(new_ckpt, args.weight_safetensors)
+    save_safetensors(new_ckpt, args.weight_safetensors)
     print(f"Convert '{args.weight_ms}' to '{args.weight_safetensors}' Done.")
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Parameter `conditioner.embedders.1.model.text_projection` is called differently in MindONE and Diffusers, so it is transposed when pre-trained weight is converted

**DETAIL:**

diffusers: 
```pooled_text_embedding = self.text_projection(input)```, where `self.text_projection` is a `torch.nn.Linear` without bias, which means `pooled_text_embedding = input @ self.text_projection.weight.T`

MindONE (and stability-AI):
```pooled_text_embedding = input @ self.text_projection.weight```, where **no transpose op**.

so we transpose this parameter manually when convert weights.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [x] Did you build and run the code without any errors?
- [x] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
