### PR TITLE
[AD] Improve train_resume.ckpt saving to adapt for resuming training automatically on modelarts

### DIFF
--- a/examples/animatediff/args_train.py
+++ b/examples/animatediff/args_train.py
@@ -17,6 +17,15 @@ def _check_cfgs_in_parser(cfgs: dict, parser: argparse.ArgumentParser):
             raise KeyError(f"{k} does not exist in ArgumentParser!")
 
 
+def _parse_bool_str(b: str):
+    """Allow input args to be either str2bool or str (e.g. a filepath)."""
+    if b.lower() not in ["false", "true"]:
+        return b
+    if b.lower() in ["false"]:
+        return False
+    return True
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -62,8 +71,8 @@ def parse_args():
     parser.add_argument(
         "--resume",
         default=False,
-        type=str,
-        help="It can be a string for path to resume checkpoint, or a bool False for not resuming.(default=False)",
+        type=_parse_bool_str,
+        help="It can be a string for absolute path to resume checkpoint, or a bool True for resuming and a bool False for not resuming.(default=False)",
     )
     # training hyper-params
     parser.add_argument("--unet_initialize_random", default=False, type=str2bool, help="initialize unet randomly")

--- a/examples/animatediff/train.py
+++ b/examples/animatediff/train.py
@@ -399,9 +399,7 @@ def main(args):
     start_epoch = 0
     if args.resume:
         resume_ckpt = (
-            os.path.join(resume_ckpt_save_dir, "train_resume.ckpt")
-            if isinstance(args.resume, bool)
-            else _to_abspath(args.resume)
+            os.path.join(resume_ckpt_save_dir, "train_resume.ckpt") if isinstance(args.resume, bool) else args.resume
         )
         if os.path.isfile(resume_ckpt):
             start_epoch, loss_scale, cur_iter, last_overflow_iter = resume_train_network(

--- a/mindone/trainers/callback.py
+++ b/mindone/trainers/callback.py
@@ -32,6 +32,7 @@ class EvalSaveCallback(Callback):
         use_lora=False,
         rank_id=0,
         ckpt_save_dir="./",
+        resume_ckpt_save_dir=None,
         output_dir=None,
         ema=None,
         ckpt_save_policy="lastest_k",
@@ -63,6 +64,7 @@ class EvalSaveCallback(Callback):
         else:
             self.output_dir = ckpt_save_dir.replace("/ckpt", "")
             self.ckpt_save_dir = ckpt_save_dir
+        self.resume_ckpt_save_dir = self.ckpt_save_dir if resume_ckpt_save_dir is None else resume_ckpt_save_dir
         self.ckpt_save_interval = ckpt_save_interval
         self.step_mode = step_mode
         self.model_name = model_name
@@ -142,7 +144,7 @@ class EvalSaveCallback(Callback):
                 # TODO: resume training for step.
                 ms.save_checkpoint(
                     cb_params.train_network,
-                    os.path.join(self.ckpt_save_dir, "train_resume.ckpt"),
+                    os.path.join(self.resume_ckpt_save_dir, "train_resume.ckpt"),
                     append_dict={
                         "epoch_num": cur_epoch,
                         "cur_step": cur_step,
@@ -221,7 +223,7 @@ class EvalSaveCallback(Callback):
 
                 ms.save_checkpoint(
                     cb_params.train_network,
-                    os.path.join(self.ckpt_save_dir, "train_resume.ckpt"),
+                    os.path.join(self.resume_ckpt_save_dir, "train_resume.ckpt"),
                     append_dict={
                         "epoch_num": cur_epoch,
                         "loss_scale": self._get_scaling_value_from_cbp(cb_params),


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Adds # (feature)
Modelarts supports automatic training resume. But the resume ckpt saving method should be improved to adapt this.

Before: `train_resume.ckpt` will save in a different directory formed by a different timestamp after each launch of resuming training. If the training will be resumed multiple times, each time we need to manually modify the `train_resume.ckpt` path (i.e. `args.resume`) to ensure that the LATEST train_resume.ckpt instead of the older one is loaded.

After: `train_resume.ckpt` is always saved in `args.output_path`. Set `args.resume` to be `True` at the first launch of training, then the latest `train_resume.ckpt` can be loaded correctly even if the training will be resumed multiple times, without setting `args.resume` again manually.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [x] Did you build and run the code without any errors?
- [x] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [x] Did you write any new necessary tests?
