### PR TITLE
perf(diffusers/sdxl): speedup sdxl training by removing redundancy `ops.randn`

### DIFF
--- a/examples/diffusers/text_to_image/README_sdxl.md
+++ b/examples/diffusers/text_to_image/README_sdxl.md
@@ -4,7 +4,7 @@ The `train_text_to_image_sdxl.py` script shows how to fine-tune Stable Diffusion
 
 🚨 This script is experimental. The script fine-tunes the whole model and often times the model overfits and runs into issues like catastrophic forgetting. It's recommended to try different hyperparameters to get the best result on your dataset. 🚨
 
-## Running locally with PyTorch
+## Running locally with MindSpore
 
 ### Installing the dependencies
 
@@ -30,7 +30,7 @@ pip install -r requirements_sdxl.txt
 ```bash
 export MODEL_NAME="stabilityai/stable-diffusion-xl-base-1.0"
 export VAE_NAME="madebyollin/sdxl-vae-fp16-fix"
-export DATASET_NAME="lambdalabs/pokemon-blip-captions"
+export DATASET_NAME="YaYaB/onepiece-blip-captions"
 
 python train_text_to_image_sdxl.py \
   --pretrained_model_name_or_path=$MODEL_NAME \
@@ -42,9 +42,9 @@ python train_text_to_image_sdxl.py \
   --max_train_steps=10000 \
   --learning_rate=1e-06 --lr_scheduler="constant" --lr_warmup_steps=0 \
   --mixed_precision="fp16" \
-  --validation_prompt="a cute Sundar Pichai creature" --validation_epochs 5 \
+  --validation_prompt="a man in a green coat holding two swords" --validation_epochs 5 \
   --checkpointing_steps=5000 \
-  --output_dir="sdxl-pokemon-model-$(date +%Y%m%d%H%M%S)"
+  --output_dir="sdxl-onepiece-model-$(date +%Y%m%d%H%M%S)"
 ```
 
 **Notes**:

--- a/mindone/diffusers/models/attention_processor.py
+++ b/mindone/diffusers/models/attention_processor.py
@@ -290,19 +290,18 @@ class Attention(nn.Cell):
             key = key.float()
 
         if attention_mask is None:
-            baddbmm_input = ops.randn(query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype)
-            beta = 0
+            attention_scores = self.scale * ops.bmm(
+                query,
+                key.swapaxes(-1, -2),
+            )
         else:
-            baddbmm_input = attention_mask
-            beta = 1
-
-        attention_scores = ops.baddbmm(
-            baddbmm_input,
-            query,
-            key.swapaxes(-1, -2),
-            beta=beta,
-            alpha=self.scale,
-        )
+            attention_scores = ops.baddbmm(
+                attention_mask,
+                query,
+                key.swapaxes(-1, -2),
+                beta=1,
+                alpha=self.scale,
+            )
 
         if self.upcast_softmax:
             attention_scores = attention_scores.float()

--- a/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -53,8 +53,8 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     Rescale `noise_cfg` according to `guidance_rescale`. Based on findings of [Common Diffusion Noise Schedules and
     Sample Steps are Flawed](https://arxiv.org/pdf/2305.08891.pdf). See Section 3.4
     """
-    std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
-    std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
+    std_text = noise_pred_text.std(axis=list(range(1, noise_pred_text.ndim)), keepdims=True)
+    std_cfg = noise_cfg.std(axis=list(range(1, noise_cfg.ndim)), keepdims=True)
     # rescale the results from guidance (fixes overexposure)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
@@ -85,8 +85,8 @@ def retrieve_timesteps(
                 must be `None`.
 
     Returns:
-        `Tuple[torch.Tensor, int]`: A tuple where the first element is the timestep schedule from the scheduler and the
-        second element is the number of inference steps.
+        `Tuple[ms.Tensor, int]`: A tuple where the first element is the timestep schedule from the scheduler and
+        the second element is the number of inference steps.
     """
     if timesteps is not None:
         accepts_timesteps = "timesteps" in set(inspect.signature(scheduler.set_timesteps).parameters.keys())
@@ -682,7 +682,7 @@ class StableDiffusionXLPipeline(DiffusionPipeline):
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) in the DDIM paper: https://arxiv.org/abs/2010.02502. Only applies to
                 [`schedulers.DDIMScheduler`], will be ignored for others.
-            generator (`random.Random` or `List[random.Random]`, *optional*):
+            generator (`np.random.Generator` or `List[np.random.Generator]`, *optional*):
                 One or a list of [torch generator(s)](https://pytorch.org/docs/stable/generated/torch.Generator.html)
                 to make generation deterministic.
             latents (`ms.Tensor`, *optional*):
@@ -915,7 +915,7 @@ class StableDiffusionXLPipeline(DiffusionPipeline):
         # 9. Optionally get Guidance Scale Embedding
         timestep_cond = None
         if self.unet.config.time_cond_proj_dim is not None:
-            guidance_scale_tensor = ops.Tensor(self.guidance_scale - 1).tile((batch_size * num_images_per_prompt,))
+            guidance_scale_tensor = ms.Tensor(self.guidance_scale - 1).tile((batch_size * num_images_per_prompt,))
             timestep_cond = self.get_guidance_scale_embedding(
                 guidance_scale_tensor, embedding_dim=self.unet.config.time_cond_proj_dim
             ).to(dtype=latents.dtype)


### PR DESCRIPTION
# What does this PR do?

- 30x faster training of diffusers-style sdxl by removing redundancy `ops.randn`. `ops.randn` runs on aicpu which is extremely slow.
- add data sinking
- fix fake progress bar can't exit if there are errors when compling
- support webdataset w/o streaming by huggingface/datasets
- fix some typos

Fixes # (issue)

Adds # (feature)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
