### PR TITLE
Revise Train Scripts [Latte and DiT]: avoid setting positional embedding to trainable parameters

### DIFF
--- a/examples/dit/sample.py
+++ b/examples/dit/sample.py
@@ -8,7 +8,6 @@ import time
 import numpy as np
 import yaml
 from PIL import Image
-from utils.model_utils import _check_cfgs_in_parser, count_params, load_dit_ckpt_params, remove_pname_prefix, str2bool
 from utils.plot import image_grid
 
 import mindspore as ms
@@ -20,6 +19,7 @@ mindone_lib_path = os.path.abspath(os.path.join(__dir__, "../../"))
 sys.path.insert(0, mindone_lib_path)
 
 from modules.autoencoder import SD_CONFIG, AutoencoderKL
+from utils.model_utils import _check_cfgs_in_parser, count_params, load_dit_ckpt_params, remove_pname_prefix, str2bool
 
 from examples.dit.pipelines.infer_pipeline import DiTInferPipeline
 from mindone.models.dit import DiT_models

--- a/examples/dit/train.py
+++ b/examples/dit/train.py
@@ -12,7 +12,6 @@ from args_train import parse_args
 from data.dataset import create_dataloader
 from data.imagenet_dataset import create_dataloader_imagenet
 from pipelines.train_pipeline import DiTWithLoss
-from utils.model_utils import load_dit_ckpt_params
 
 import mindspore as ms
 from mindspore import Model, nn
@@ -26,6 +25,7 @@ sys.path.insert(0, mindone_lib_path)
 
 from diffusion import create_diffusion
 from modules.autoencoder import SD_CONFIG, AutoencoderKL
+from utils.model_utils import load_dit_ckpt_params
 
 from mindone.env import init_train_env
 from mindone.models.dit import DiT_models

--- a/examples/dit/train.py
+++ b/examples/dit/train.py
@@ -46,22 +46,6 @@ os.environ["HCCL_CONNECT_TIMEOUT"] = "6000"
 logger = logging.getLogger(__name__)
 
 
-def set_dit_all_params(dit_model, train=True, **kwargs):
-    n_params_trainable = 0
-    for param in dit_model.get_parameters():
-        param.requires_grad = train
-        if train:
-            n_params_trainable += 1
-    logger.info(f"Set {n_params_trainable} params to train.")
-
-
-def set_dit_params(dit_model, ft_all_params, **kwargs):
-    if ft_all_params:
-        set_dit_all_params(dit_model, **kwargs)
-    else:
-        raise ValueError("Fintuning partial params is not supported!")
-
-
 def main(args):
     time_str = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     args.output_path = os.path.join(args.output_path, time_str)
@@ -102,8 +86,6 @@ def main(args):
     else:
         logger.info("Initialize DIT ramdonly")
     dit_model.set_train(True)
-
-    set_dit_params(dit_model, ft_all_params=True, train=True)
 
     # 2.2 vae
     logger.info("vae init")

--- a/examples/dit/utils/model_utils.py
+++ b/examples/dit/utils/model_utils.py
@@ -38,6 +38,8 @@ def load_dit_ckpt_params(model, ckpt):
         )
 
     logger.info("Net params not load: {}, Total net params not loaded: {}".format(param_not_load, len(param_not_load)))
+    if "pos_embed" in ckpt_not_load:
+        ckpt_not_load.remove("pos_embed")
     logger.info("Ckpt params not load: {}, Total ckpt params not loaded: {}".format(ckpt_not_load, len(ckpt_not_load)))
     return model
 

--- a/examples/dit/utils/model_utils.py
+++ b/examples/dit/utils/model_utils.py
@@ -39,6 +39,7 @@ def load_dit_ckpt_params(model, ckpt):
 
     logger.info("Net params not load: {}, Total net params not loaded: {}".format(param_not_load, len(param_not_load)))
     logger.info("Ckpt params not load: {}, Total ckpt params not loaded: {}".format(ckpt_not_load, len(ckpt_not_load)))
+    return model
 
 
 def str2bool(b):

--- a/examples/latte/train.py
+++ b/examples/latte/train.py
@@ -93,8 +93,6 @@ def main(args):
         logger.info("Use random initialization for Latte")
     # set train
     latte_model.set_train(True)
-    for param in latte_model.get_parameters():
-        param.requires_grad = True
 
     # select dataset
     data_config = OmegaConf.load(args.data_config_file).data_config

--- a/mindone/models/dit.py
+++ b/mindone/models/dit.py
@@ -490,8 +490,8 @@ class DiT(nn.Cell):
         self.t_embedder = TimestepEmbedder(hidden_size)
         self.y_embedder = LabelEmbedder(num_classes, hidden_size, class_dropout_prob)
         num_patches = self.x_embedder.num_patches
-        # Will use fixed sin-cos embedding:
-        self.pos_embed = Parameter(ops.zeros((1, num_patches, hidden_size)), requires_grad=False)
+        # Will use fixed sin-cos embedding (saved in tensor):
+        self.pos_embed = ops.zeros((1, num_patches, hidden_size))
 
         self.blocks = nn.CellList(
             [DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio, **block_kwargs) for _ in range(depth)]
@@ -523,7 +523,7 @@ class DiT(nn.Cell):
 
         # Initialize (and freeze) pos_embed by sin-cos embedding:
         pos_embed = get_2d_sincos_pos_embed(self.pos_embed.shape[-1], int(self.x_embedder.num_patches**0.5))
-        self.pos_embed.set_data(Tensor(pos_embed).float().unsqueeze(0))
+        self.pos_embed = Tensor(pos_embed).float().unsqueeze(0)
 
         # Initialize patch_embed like nn.Linear (instead of nn.Conv2d):
         w = self.x_embedder.proj.weight

--- a/mindone/models/latte.py
+++ b/mindone/models/latte.py
@@ -81,8 +81,8 @@ class Latte(nn.Cell):
             )
         num_patches = self.x_embedder.num_patches
         # Will use fixed sin-cos embedding:
-        self.pos_embed = ms.Parameter(ops.zeros((1, num_patches, hidden_size), dtype=ms.float32), requires_grad=False)
-        self.temp_embed = ms.Parameter(ops.zeros((1, num_frames, hidden_size), dtype=ms.float32), requires_grad=False)
+        self.pos_embed = ops.zeros((1, num_patches, hidden_size), dtype=ms.float32)
+        self.temp_embed = ops.zeros((1, num_frames, hidden_size), dtype=ms.float32)
 
         self.blocks = nn.CellList(
             [DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio, **block_kwargs) for _ in range(depth)]
@@ -115,9 +115,9 @@ class Latte(nn.Cell):
 
         # Initialize (and freeze) pos_embed (temp_embed) by sin-cos embedding:
         pos_embed = get_2d_sincos_pos_embed(self.pos_embed.shape[-1], int(self.x_embedder.num_patches**0.5))
-        self.pos_embed.set_data(Tensor(pos_embed).float().unsqueeze(0))
+        self.pos_embed = Tensor(pos_embed).float().unsqueeze(0)
         temp_embed = get_1d_sincos_temp_embed(self.temp_embed.shape[-1], self.temp_embed.shape[-2])
-        self.temp_embed.set_data(Tensor(temp_embed).float().unsqueeze(0))
+        self.temp_embed = Tensor(temp_embed).float().unsqueeze(0)
 
         # Initialize patch_embed like nn.Linear (instead of nn.Conv2d):
         w = self.x_embedder.proj.weight

--- a/mindone/models/latte.py
+++ b/mindone/models/latte.py
@@ -283,6 +283,10 @@ class Latte(nn.Cell):
         logger.info(
             "Net params not load: {}, Total net params not loaded: {}".format(param_not_load, len(param_not_load))
         )
+        if "pos_embed" in ckpt_not_load:
+            ckpt_not_load.remove("pos_embed")
+        if "temp_embed" in ckpt_not_load:
+            ckpt_not_load.remove("temp_embed")
         logger.info(
             "Ckpt params not load: {}, Total ckpt params not loaded: {}".format(ckpt_not_load, len(ckpt_not_load))
         )


### PR DESCRIPTION
For DiT and Latte models, the positional embedding tensor is initialized as a Parameter that does not require gradient updates.

However, in the training script, I accidently set all parameters to trainable. It is not desirable for positional embeddings, because they are initialized and then fixed during training.