### PR TITLE
Revert PNDM scheduler

### DIFF
--- a/mindone/diffusers/schedulers/scheduling_pndm.py
+++ b/mindone/diffusers/schedulers/scheduling_pndm.py
@@ -220,8 +220,6 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
 
         timesteps = np.concatenate([self.prk_timesteps, self.plms_timesteps]).astype(np.int64)
         self.timesteps = ms.Tensor(timesteps)
-        self.prk_timesteps = ms.Tensor(self.prk_timesteps)
-        self.plms_timesteps = ms.Tensor(self.plms_timesteps)
 
         self.ets = []
         self.counter = 0


### PR DESCRIPTION
Undo the changes to diffusers/schedulers/scheduling_pndm.py.
