### PR TITLE
fix(diffusers/layers): remove additional arguments used in construct()

### DIFF
--- a/mindone/diffusers/models/attention_processor.py
+++ b/mindone/diffusers/models/attention_processor.py
@@ -725,8 +725,6 @@ class AttnAddedKVProcessor:
         hidden_states: ms.Tensor,
         encoder_hidden_states: Optional[ms.Tensor] = None,
         attention_mask: Optional[ms.Tensor] = None,
-        *args,
-        **kwargs,
     ) -> ms.Tensor:
         residual = hidden_states
 

--- a/mindone/diffusers/models/resnet.py
+++ b/mindone/diffusers/models/resnet.py
@@ -144,7 +144,7 @@ class ResnetBlockCondNorm2D(nn.Cell):
                 has_bias=conv_shortcut_bias,
             )
 
-    def construct(self, input_tensor: ms.Tensor, temb: ms.Tensor, *args, **kwargs) -> ms.Tensor:
+    def construct(self, input_tensor: ms.Tensor, temb: ms.Tensor) -> ms.Tensor:
         hidden_states = input_tensor
 
         hidden_states = self.norm1(hidden_states, temb)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes bugs in `mindone.diffusers.models`:

Existing additional arguments used in `nn.Cell.construct()` such as `*args` raise errors in static graph mode, therefore we remove all these arguments as they are not used actually.

These modules are affected:

- `AttnAddedKVProcessor` (in mindone.diffusers.models.attention_processor.py)
- `ResnetBlockCondNorm2D` (in mindone.diffusers.models.resnet.py)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
