### PR TITLE
fix(diffusers/pipelines): fix vae encoding in pipelines

### DIFF
--- a/mindone/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/mindone/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -69,7 +69,7 @@ def retrieve_latents(vae, encoder_output: ms.Tensor, sample_mode: str = "sample"
     if sample_mode == "sample":
         return vae.diag_gauss_dist.sample(encoder_output)
     elif sample_mode == "argmax":
-        return vae.diag_gauss_dist.sample(encoder_output).argmax()
+        return vae.diag_gauss_dist.mode(encoder_output)
     # This branch is not needed because the encoder_output type is ms.Tensor as per AutoencoderKLOutput change
     # elif hasattr(encoder_output, "latents"):
     #     return encoder_output.latents

--- a/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -74,7 +74,7 @@ def retrieve_latents(vae, encoder_output: ms.Tensor, sample_mode: str = "sample"
     if sample_mode == "sample":
         return vae.diag_gauss_dist.sample(encoder_output)
     elif sample_mode == "argmax":
-        return vae.diag_gauss_dist.sample(encoder_output).argmax()
+        return vae.diag_gauss_dist.mode(encoder_output)
     # This branch is not needed because the encoder_output type is ms.Tensor as per AutoencoderKLOutput change
     # elif hasattr(encoder_output, "latents"):
     #     return encoder_output.latents

--- a/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/mindone/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -216,7 +216,7 @@ def retrieve_latents(vae, encoder_output: ms.Tensor, sample_mode: str = "sample"
     if sample_mode == "sample":
         return vae.diag_gauss_dist.sample(encoder_output)
     elif sample_mode == "argmax":
-        return vae.diag_gauss_dist.sample(encoder_output).argmax()
+        return vae.diag_gauss_dist.mode(encoder_output)
     # This branch is not needed because the encoder_output type is ms.Tensor as per AutoencoderKLOutput change
     # elif hasattr(encoder_output, "latents"):
     #     return encoder_output.latents


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

### Fix incorrect calling for `vae.diag_gauss_dist`

In pipelines for img2img, inpainting and other tasks using images as inputs (such as `StableDiffusionImg2ImgPipeline`), image inputs would be encoded into a gaussian distribution by `pipeline.vae.encode()`, then pipelines would use `retrieve_latents()` function to sample a deterministic latent tensor from this distribution. `retrieve_latents()` offers parameter `sample_mode` to select the method of sampling latent tensor.

Argument `sample_mode="argmax"` is supposed to mean that $$latents = \mathop{argmax}\limits_{x}\ P_z(x)$$

,where $P_z$ is the probility of encoded gaussian distribution, which means latents is the mean of the distribution in this case. Therefore the origin codes should be corrected to:

```diff
def retrieve_latents(vae, encoder_output: ms.Tensor, sample_mode: str = "sample"):
    ...
    elif sample_mode == "argmax":
-        return vae.diag_gauss_dist.sample(encoder_output).argmax()
+        return vae.diag_gauss_dist.mode(encoder_output)
    ...
```

We fixed all the existing pipelines involving this function.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
