### PR TITLE
[OpenSora-PKU V1.0]: parse env kbk and ge

### DIFF
--- a/examples/opensora_pku/.env.ge
+++ b/examples/opensora_pku/.env.ge
@@ -1,0 +1,2 @@
+export MS_ENABLE_ACLNN=0
+export GRAPH_OP_RUN=0

--- a/examples/opensora_pku/.env.kbk
+++ b/examples/opensora_pku/.env.kbk
@@ -1,0 +1,2 @@
+export MS_ENABLE_ACLNN=1
+export GRAPH_OP_RUN=1

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -283,15 +283,9 @@ After running, the text embeddings saved as npz file for each caption will be in
 
 #### Notes about MindSpore Features
 
-Training on MS2.3 allows much better performance with its new features (such as kbk and dvm)
+Training on MS2.3 allows much better performance with its new features (such as kbk and dvm).
 
-To enable kbk mode on ms2.3, we use the following two environmental variables:
-```
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
-
-```
-By default, we have enabled kbk mode in all of our training scripts already.
+By default, we have enabled kbk mode in all of our training and inference scripts already. See `--kernel_engine` in the training and inference scripts for more information.
 
 To improve training performance, you may append `--enable_dvm=True` to the training command.
 Furthermore, you may accelerate the data loading speed by setting `--dataset_sink_mode=True` to the training command. Please be aware that when data sink mode is on, there will not be per-step printing messages. We recommend to use data sink mode after all hyper-parameters tuning is done.
@@ -304,7 +298,8 @@ There some hyper-parameters that may vary between different experiments:
 image_size=256  # the image size of frames, same to image height and image width
 use_image_num=4  # to include n number of images in an input sample
 num_frames=17  # to sample m frames from a single video. The total number of images： num_frames + use_image_num = 17+4
-model_dtype="fp16" # the data type used for mixed precision of the diffusion transformer model. Default amp level is O1.
+model_dtype="fp16" # the data type used for mixed precision of the diffusion transformer model.
+amp_level="O1" # Default amp level is O1 for fp16. One can use bf16 with amp_level O2 as well.
 enable_flash_attention="True" # whether to use MindSpore Flash Attention
 batch_size=4 # training batch size
 lr="2e-05" # learning rate. Default learning schedule is constant
@@ -359,7 +354,7 @@ bash scripts/text_condition/train_videoae_65x512x512.sh
 
 We evaluated the training performance on MindSpore and Ascend NPUs. The results are as follows.
 
-| Model           | Context        | Precision | BS | NPUs | num_frames + num_images| Resolution  | Train T. (s/step) |
+| Model           | Context        | LatteT2V Precision | BS | NPUs | num_frames + num_images| Resolution  | Train T. (s/step) |
 |:----------------|:---------------|:----------|:--:|:----:|:-----------:|:-----------:|:--------------:|
 | LatteT2V-XL/122 | D910\*x1-MS2.3 | FP16      | 4  |  8   |   17 + 4    | 256x256     |   1.8     |
 | LatteT2V-XL/122 | D910\*x1-MS2.3 | FP16      | 4  |  8   |   65 + 4    | 256x256     |   4.5     |

--- a/examples/opensora_pku/examples/rec_imvi_vae.py
+++ b/examples/opensora_pku/examples/rec_imvi_vae.py
@@ -34,7 +34,7 @@ sys.path.append(".")
 from opensora.models.ae import getae_model_config, getae_wrapper
 from opensora.models.ae.videobase.causal_vae.modeling_causalvae import TimeDownsample2x, TimeUpsample2x
 from opensora.utils.dataset_utils import create_video_transforms
-from opensora.utils.utils import get_precision
+from opensora.utils.utils import get_precision, parse_env
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +213,7 @@ if __name__ == "__main__":
     parser.add_argument("--enable_time_chunk", action="store_true")
     # ms related
     parser.add_argument("--mode", default=0, type=int, help="Specify the mode: 0 for graph mode, 1 for pynative mode")
+    parser.add_argument("--kernel_engine", default="kbk", help="Set the kernel engine type, such as kbk and ge.")
     parser.add_argument(
         "--precision",
         default="bf16",
@@ -237,4 +238,5 @@ if __name__ == "__main__":
         help="whether to use grid to show original and reconstructed data",
     )
     args = parser.parse_args()
+    parse_env(args.kernel_engine)
     main(args)

--- a/examples/opensora_pku/examples/rec_video_vae.py
+++ b/examples/opensora_pku/examples/rec_video_vae.py
@@ -20,7 +20,7 @@ sys.path.append(".")
 from opensora.models.ae import getae_model_config, getae_wrapper
 from opensora.models.ae.videobase.causal_vae.modeling_causalvae import TimeDownsample2x, TimeUpsample2x
 from opensora.models.ae.videobase.dataset_videobase import VideoDataset, create_dataloader
-from opensora.utils.utils import get_precision
+from opensora.utils.utils import get_precision, parse_env
 
 logger = logging.getLogger(__name__)
 
@@ -182,6 +182,7 @@ if __name__ == "__main__":
     parser.add_argument("--enable_tiling", action="store_true")
     parser.add_argument("--output_origin", action="store_true")
     parser.add_argument("--mode", default=0, type=int, help="Specify the mode: 0 for graph mode, 1 for pynative mode")
+    parser.add_argument("--kernel_engine", default="kbk", help="Set the kernel engine type, such as kbk and ge.")
     parser.add_argument(
         "--precision",
         default="bf16",
@@ -202,4 +203,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    parse_env(args.kernel_engine)
     main(args)

--- a/examples/opensora_pku/opensora/sample/sample_t2v.py
+++ b/examples/opensora_pku/opensora/sample/sample_t2v.py
@@ -26,7 +26,7 @@ from opensora.models.ae.videobase.causal_vae.modeling_causalvae import TimeDowns
 from opensora.models.diffusion.latte.modeling_latte import LatteT2V, LayerNorm
 from opensora.models.diffusion.latte.modules import Attention
 from opensora.models.text_encoder.t5 import T5Embedder
-from opensora.utils.utils import _check_cfgs_in_parser, get_precision
+from opensora.utils.utils import _check_cfgs_in_parser, get_precision, parse_env
 from pipeline_videogen import VideoGenPipeline
 
 from mindone.diffusers.schedulers import DDIMScheduler, DDPMScheduler, EulerDiscreteScheduler, PNDMScheduler
@@ -174,6 +174,7 @@ def parse_args():
     parser.add_argument("--device", type=str, default="Ascend", help="Ascend or GPU")
     parser.add_argument("--max_device_memory", type=str, default=None, help="e.g. `30GB` for 910a, `59GB` for 910b")
     parser.add_argument("--mode", default=0, type=int, help="Specify the mode: 0 for graph mode, 1 for pynative mode")
+    parser.add_argument("--kernel_engine", default="kbk", help="Set the kernel engine type, such as kbk and ge.")
     parser.add_argument("--use_parallel", default=False, type=str2bool, help="use parallel")
     parser.add_argument(
         "--parallel_mode", default="data", type=str, choices=["data", "optim"], help="parallel mode: data, optim"
@@ -249,6 +250,7 @@ def parse_args():
 if __name__ == "__main__":
     # 1. init env
     args = parse_args()
+    parse_env(args.kernel_engine)
     save_dir = args.save_img_path
     os.makedirs(save_dir, exist_ok=True)
     set_logger(name="", output_dir=save_dir)

--- a/examples/opensora_pku/opensora/sample/sample_text_embed.py
+++ b/examples/opensora_pku/opensora/sample/sample_text_embed.py
@@ -18,7 +18,7 @@ sys.path.insert(0, mindone_lib_path)
 sys.path.append(os.path.abspath("./"))
 from opensora.dataset.text_dataset import create_dataloader
 from opensora.models.text_encoder.t5 import T5Embedder
-from opensora.utils.utils import get_precision
+from opensora.utils.utils import get_precision, parse_env
 
 from mindone.utils.amp import auto_mixed_precision
 from mindone.utils.config import str2bool
@@ -252,6 +252,7 @@ def parse_args():
     # MS new args
     parser.add_argument("--device_target", type=str, default="Ascend", help="Ascend or GPU")
     parser.add_argument("--mode", type=int, default=0, help="Running in GRAPH_MODE(0) or PYNATIVE_MODE(1) (default=0)")
+    parser.add_argument("--kernel_engine", default="kbk", help="Set the kernel engine type, such as kbk and ge.")
     parser.add_argument("--use_parallel", default=False, type=str2bool, help="use parallel")
     parser.add_argument("--seed", type=int, default=4, help="Inference seed")
     parser.add_argument(
@@ -309,4 +310,5 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+    parse_env(args.kernel_engine)
     main(args)

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -126,6 +126,7 @@ def parse_train_args(parser):
     parser.add_argument("--device", type=str, default="Ascend", help="Ascend or GPU")
     parser.add_argument("--max_device_memory", type=str, default=None, help="e.g. `30GB` for 910a, `59GB` for 910b")
     parser.add_argument("--mode", default=0, type=int, help="Specify the mode: 0 for graph mode, 1 for pynative mode")
+    parser.add_argument("--kernel_engine", default="kbk", help="Set the kernel engine type, such as kbk and ge.")
     parser.add_argument("--use_parallel", default=False, type=str2bool, help="use parallel")
     parser.add_argument(
         "--parallel_mode",

--- a/examples/opensora_pku/opensora/train/train_causalvae.py
+++ b/examples/opensora_pku/opensora/train/train_causalvae.py
@@ -22,7 +22,7 @@ from opensora.models.ae.videobase.causal_vae.modeling_causalvae import TimeDowns
 from opensora.models.ae.videobase.dataset_videobase import VideoDataset, create_dataloader
 from opensora.models.ae.videobase.losses.net_with_loss import DiscriminatorWithLoss, GeneratorWithLoss
 from opensora.train.commons import create_loss_scaler, init_env, parse_args
-from opensora.utils.utils import get_precision
+from opensora.utils.utils import get_precision, parse_env
 
 from mindone.trainers.callback import EvalSaveCallback, OverflowMonitor, ProfilerCallback
 from mindone.trainers.checkpoint import CheckpointManager, resume_train_network
@@ -36,6 +36,9 @@ from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
 logger = logging.getLogger(__name__)
+
+os.environ["HCCL_CONNECT_TIMEOUT"] = "6000"
+os.environ["MS_ASCEND_CHECK_OVERFLOW_MODE"] = "INFNAN_MODE"
 
 
 def main(args):
@@ -416,4 +419,5 @@ def parse_causalvae_train_args(parser):
 
 if __name__ == "__main__":
     args = parse_args(additional_parse_args=parse_causalvae_train_args)
+    parse_env(args.kernel_engine)
     main(args)

--- a/examples/opensora_pku/opensora/utils/utils.py
+++ b/examples/opensora_pku/opensora/utils/utils.py
@@ -1,7 +1,10 @@
 import argparse
 import html
+import logging
 import re
 import urllib.parse as ul
+
+from environs import Env
 
 import mindspore as ms
 
@@ -14,6 +17,9 @@ try:
     import ftfy
 except ImportError:
     is_ftfy_available = False
+
+
+_logger = logging.getLogger(__name__)
 
 
 def get_experiment_dir(root_dir, args):
@@ -41,6 +47,19 @@ def get_precision(mixed_precision):
     else:
         dtype = ms.float32
     return dtype
+
+
+def parse_env(kernel_engine="kbk"):
+    env = Env()
+    if kernel_engine == "kbk":
+        env.read_env(".env.kbk")
+        _logger.info("Using KBK as kernel engine")
+    elif kernel_engine == "ge":
+        env.read_env(".env.ge")
+        _logger.info("Using GE as kernel engine")
+    else:
+        raise NotImplementedError(f"Not supported kernel engine {kernel_engine}. " "Now only supports kbk and ge.")
+    return env
 
 
 #################################################################################

--- a/examples/opensora_pku/requirements.txt
+++ b/examples/opensora_pku/requirements.txt
@@ -19,3 +19,4 @@ sentencepiece
 transformers>=4.39.3
 pyav
 huggingface_hub>=0.22.2
+environs

--- a/examples/opensora_pku/scripts/causalvae/gen_video.sh
+++ b/examples/opensora_pku/scripts/causalvae/gen_video.sh
@@ -1,5 +1,3 @@
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 python examples/rec_video_vae.py \
     --batch_size 1 \
     --real_video_dir ../test_eval/eyes_test \

--- a/examples/opensora_pku/scripts/causalvae/reconstruction.sh
+++ b/examples/opensora_pku/scripts/causalvae/reconstruction.sh
@@ -1,5 +1,3 @@
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 python examples/rec_imvi_vae.py \
     --model_path LanguageBind/Open-Sora-Plan-v1.0.0/vae \
     --video_path test.mp4 \

--- a/examples/opensora_pku/scripts/causalvae/train.sh
+++ b/examples/opensora_pku/scripts/causalvae/train.sh
@@ -1,5 +1,3 @@
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 python opensora/train/train_causalvae.py \
     --exp_name "exp_name" \
     --batch_size 1 \

--- a/examples/opensora_pku/scripts/text_condition/sample_image.sh
+++ b/examples/opensora_pku/scripts/text_condition/sample_image.sh
@@ -1,5 +1,3 @@
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 python opensora/sample/sample_t2v.py \
     --model_path LanguageBind/Open-Sora-Plan-v1.0.0 \
     --text_encoder_name DeepFloyd/t5-v1_1-xxl \

--- a/examples/opensora_pku/scripts/text_condition/sample_video.sh
+++ b/examples/opensora_pku/scripts/text_condition/sample_video.sh
@@ -1,5 +1,3 @@
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 python opensora/sample/sample_t2v.py \
     --model_path LanguageBind/Open-Sora-Plan-v1.0.0 \
     --text_encoder_name DeepFloyd/t5-v1_1-xxl \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_17x256x256.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_17x256x256.sh
@@ -1,10 +1,5 @@
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export MS_ENABLE_NUMA=0
-export MS_MEMORY_STATISTIC=1
-
-# enable kbk
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 export GLOG_v=2
 
 # hyper-parameters
@@ -12,6 +7,7 @@ image_size=256
 use_image_num=4
 num_frames=17
 model_dtype="fp16"
+amp_level="O1"
 enable_flash_attention="True"
 batch_size=4
 lr="2e-05"
@@ -40,6 +36,7 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --lr_scheduler="constant" \
     --lr_warmup_steps=0 \
     --precision=$model_dtype \
+    --amp_level=$amp_level \
     --checkpointing_steps=500 \
     --output_dir=$output_dir \
     --model_max_length 300 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_17x512x512.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_17x512x512.sh
@@ -1,10 +1,5 @@
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export MS_ENABLE_NUMA=0
-export MS_MEMORY_STATISTIC=1
-
-# enable kbk
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 export GLOG_v=2
 
 # hyper-parameters
@@ -12,6 +7,7 @@ image_size=512
 use_image_num=4
 num_frames=17
 model_dtype="fp16"
+amp_level="O1"
 enable_flash_attention="True"
 batch_size=4
 lr="2e-05"
@@ -40,6 +36,7 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --lr_scheduler="constant" \
     --lr_warmup_steps=0 \
     --precision=$model_dtype \
+    --amp_level=$amp_level \
     --checkpointing_steps=500 \
     --output_dir=$output_dir \
     --model_max_length 300 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x256x256.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x256x256.sh
@@ -1,10 +1,5 @@
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export MS_ENABLE_NUMA=0
-export MS_MEMORY_STATISTIC=1
-
-# enable kbk
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 export GLOG_v=2
 
 # hyper-parameters
@@ -12,6 +7,7 @@ image_size=256
 use_image_num=4
 num_frames=65
 model_dtype="fp16"
+amp_level="O1"
 enable_flash_attention="True"
 batch_size=4
 lr="2e-05"
@@ -40,6 +36,7 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --lr_scheduler="constant" \
     --lr_warmup_steps=0 \
     --precision=$model_dtype \
+    --amp_level=$amp_level \
     --checkpointing_steps=500 \
     --output_dir=$output_dir \
     --model_max_length 300 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512.sh
@@ -1,10 +1,5 @@
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export MS_ENABLE_NUMA=0
-export MS_MEMORY_STATISTIC=1
-
-# enable kbk
-export MS_ENABLE_ACLNN=1
-export GRAPH_OP_RUN=1
 export GLOG_v=2
 
 # hyper-parameters
@@ -12,6 +7,7 @@ image_size=512
 use_image_num=16
 num_frames=65
 model_dtype="fp16"
+amp_level="O1"
 enable_flash_attention="True"
 batch_size=2
 lr="2e-05"
@@ -40,6 +36,7 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --lr_scheduler="constant" \
     --lr_warmup_steps=0 \
     --precision=$model_dtype \
+    --amp_level=$amp_level \
     --checkpointing_steps=500 \
     --output_dir=$output_dir \
     --model_max_length 300 \


### PR DESCRIPTION
Use .env to define the kbk or ge mode instead of exporting environmental variables.