### PR TITLE
Opensora-PKU: fix fa attention mask

### DIFF
--- a/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
+++ b/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
@@ -1426,28 +1426,16 @@ class LatteT2V(ModelMixin, ConfigMixin):
         if attention_mask is not None and attention_mask.ndim == 2:
             # assume that mask is expressed as:
             #   (1 = keep,      0 = discard)
-            # convert mask into a bias that can be added to attention scores:
-            #       (keep = +0,     discard = -10000.0)
             attention_mask = attention_mask.unsqueeze(1)
-            # do not fill in -10000.0 until entering MHA
-            # attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -10000.0)
             attention_mask = attention_mask.to(self.dtype)
         # 1 + 4, 1 -> video condition, 4 -> image condition
         # convert encoder_attention_mask to a bias the same way we do for attention_mask
         if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:  # ndim == 2 means no image joint
             encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
-            # do not fill in -10000.0 until entering MHA
-            # encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
-            #     ~encoder_attention_mask, -10000.0
-            # )
             # b 1 l -> (b f) 1 l
             encoder_attention_mask = encoder_attention_mask.repeat_interleave(frame, dim=0)
             encoder_attention_mask = encoder_attention_mask.to(self.dtype)
         elif encoder_attention_mask is not None and encoder_attention_mask.ndim == 3:  # ndim == 3 means image joint
-            # do not fill in -10000.0 until entering MHA
-            # encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
-            #     ~encoder_attention_mask, -10000.0
-            # )
             encoder_attention_mask_video = encoder_attention_mask[:, :1, ...]
             encoder_attention_mask_video = encoder_attention_mask_video.repeat_interleave(frame, dim=1)
             encoder_attention_mask_image = encoder_attention_mask[:, 1:, ...]

--- a/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
+++ b/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
@@ -832,9 +832,9 @@ class Latte(ModelMixin, ConfigMixin):
             # assume that mask is expressed as:
             #   (1 = keep,      0 = discard)
             # convert mask into a bias that can be added to attention scores:
-            #       (keep = +0,     discard = -10000.0)
+            #       (keep = +0,     discard = -ms.numpy.inf)
             attention_mask = attention_mask.unsqueeze(1)  # (b, 1, key_len)
-            attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -10000.0)
+            attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -ms.numpy.inf)
 
         # # Retrieve lora scale.
         # lora_scale = cross_attention_kwargs.get("scale", 1.0) if cross_attention_kwargs is not None else 1.0

--- a/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
+++ b/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
@@ -832,9 +832,9 @@ class Latte(ModelMixin, ConfigMixin):
             # assume that mask is expressed as:
             #   (1 = keep,      0 = discard)
             # convert mask into a bias that can be added to attention scores:
-            #       (keep = +0,     discard = -ms.numpy.inf)
+            #       (keep = +0,     discard = -10000.0)
             attention_mask = attention_mask.unsqueeze(1)  # (b, 1, key_len)
-            attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -ms.numpy.inf)
+            attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -10000.0)
 
         # # Retrieve lora scale.
         # lora_scale = cross_attention_kwargs.get("scale", 1.0) if cross_attention_kwargs is not None else 1.0
@@ -1427,24 +1427,27 @@ class LatteT2V(ModelMixin, ConfigMixin):
             # assume that mask is expressed as:
             #   (1 = keep,      0 = discard)
             # convert mask into a bias that can be added to attention scores:
-            #       (keep = +0,     discard = -ms.numpy.inf)
+            #       (keep = +0,     discard = -10000.0)
             attention_mask = attention_mask.unsqueeze(1)
-            attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -ms.numpy.inf)
+            # do not fill in -10000.0 until entering MHA
+            # attention_mask = ops.zeros(attention_mask.shape).masked_fill(~attention_mask, -10000.0)
             attention_mask = attention_mask.to(self.dtype)
         # 1 + 4, 1 -> video condition, 4 -> image condition
         # convert encoder_attention_mask to a bias the same way we do for attention_mask
         if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:  # ndim == 2 means no image joint
             encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
-            encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
-                ~encoder_attention_mask, -ms.numpy.inf
-            )
+            # do not fill in -10000.0 until entering MHA
+            # encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
+            #     ~encoder_attention_mask, -10000.0
+            # )
             # b 1 l -> (b f) 1 l
             encoder_attention_mask = encoder_attention_mask.repeat_interleave(frame, dim=0)
             encoder_attention_mask = encoder_attention_mask.to(self.dtype)
         elif encoder_attention_mask is not None and encoder_attention_mask.ndim == 3:  # ndim == 3 means image joint
-            encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
-                ~encoder_attention_mask, -ms.numpy.inf
-            )
+            # do not fill in -10000.0 until entering MHA
+            # encoder_attention_mask = ops.zeros(encoder_attention_mask.shape).masked_fill(
+            #     ~encoder_attention_mask, -10000.0
+            # )
             encoder_attention_mask_video = encoder_attention_mask[:, :1, ...]
             encoder_attention_mask_video = encoder_attention_mask_video.repeat_interleave(frame, dim=1)
             encoder_attention_mask_image = encoder_attention_mask[:, 1:, ...]

--- a/examples/opensora_pku/opensora/models/diffusion/latte/modules.py
+++ b/examples/opensora_pku/opensora/models/diffusion/latte/modules.py
@@ -57,8 +57,10 @@ class Attention(nn.Cell):
             sim = sim.astype(ms.float32)
         if mask is not None:
             # (b*h 1 n_k)
-            mask = mask.to(ms.bool_)
-            sim = ops.masked_fill(sim, mask, -ms.numpy.inf)  # FIXME: whether to use -inf or -10000.0 as torch repo?
+            # convert mask into a bias that can be added to attention scores:
+            #       (keep = +0,     discard = -10000.0)
+            mask = ops.zeros(mask.shape).masked_fill(mask.to(ms.bool_), -10000.0)
+            sim += mask
 
         # use fp32 for exponential inside
         attn = self.softmax(sim).astype(v.dtype)

--- a/examples/opensora_pku/opensora/sample/sample_t2v.py
+++ b/examples/opensora_pku/opensora/sample/sample_t2v.py
@@ -189,7 +189,7 @@ def parse_args():
     )
     parser.add_argument(
         "--precision",
-        default="fp16",
+        default="bf16",
         type=str,
         choices=["bf16", "fp16", "fp32"],
         help="what data type to use for latte. Default is `fp16`, which corresponds to ms.float16",
@@ -379,7 +379,7 @@ if __name__ == "__main__":
                 transformer_model,
                 amp_level=args.amp_level,
                 dtype=dtype,
-                custom_fp32_cells=[LayerNorm, Attention, nn.SiLU],
+                custom_fp32_cells=[LayerNorm, Attention, nn.SiLU] if args.precision == "fp16" else [],
             )
             logger.info(f"Set mixed precision to O2 with dtype={args.precision}")
         else:

--- a/examples/opensora_pku/opensora/sample/sample_t2v.py
+++ b/examples/opensora_pku/opensora/sample/sample_t2v.py
@@ -442,6 +442,7 @@ if __name__ == "__main__":
             f"Num params: {num_params:,} (latte: {num_params_latte:,}, vae: {num_params_vae:,})",
             f"Num trainable params: {num_params_trainable:,}",
             f"Use model dtype: {dtype}",
+            f"Use FA: {args.enable_flash_attention}",
             f"Sampling steps {args.num_sampling_steps}",
             f"Sampling method: {args.sample_method}",
             f"CFG guidance scale: {args.guidance_scale}",

--- a/examples/opensora_pku/opensora/sample/sample_t2v.py
+++ b/examples/opensora_pku/opensora/sample/sample_t2v.py
@@ -189,7 +189,7 @@ def parse_args():
     )
     parser.add_argument(
         "--precision",
-        default="bf16",
+        default="fp16",
         type=str,
         choices=["bf16", "fp16", "fp32"],
         help="what data type to use for latte. Default is `fp16`, which corresponds to ms.float16",

--- a/examples/opensora_pku/opensora/sample/sample_text_embed.py
+++ b/examples/opensora_pku/opensora/sample/sample_text_embed.py
@@ -173,8 +173,8 @@ def main(args):
 
                 np.savez(
                     npz_fp,
-                    mask=mask[i].asnumpy().astype(np.uint8),
-                    text_emb=text_emb[i].asnumpy().astype(np.float32),
+                    mask=mask[i].float().asnumpy().astype(np.uint8),
+                    text_emb=text_emb[i].float().asnumpy().astype(np.float32),
                     # tokens=text_tokens[i].asnumpy(), #.astype(np.int32),
                 )
         logger.info(f"Curretn step time cost: {time_cost:0.3f}s")


### PR DESCRIPTION
FlashAttention in MindSpore only accepts mask with (0, 1), where 0 means to keep, and 1 means to discard.

Editing the current Opensora-PKU attention mask:
1. comment the code to fill in mask with `-ms.numpy.inf` in `LatteT2V.construct`;
2. Flip the mask using `1 - mask` since FA treats 1 as discard, 0 as retain.
3. Fill in with `-ms.numpy.inf` in vanilla Attention, and leave the mask untouched for FA

Minor changes: 
1. Print `Use FA` in `sample_t2v.py`;
2. Force tensor to fp32 before saving to `npz` in  `sample_text_embed.py`.