### PR TITLE
OpenSora-pku v1.1: improve training speed and documents

### DIFF
--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -406,7 +406,7 @@ For the detailed explanations for other arguments, please refer to the document 
 
 > Note:
 > - In Graph mode (default), MindSpore takes about 10~20 mins for graph compilation.
-> - For acceleration, we set the `dataset_sink_mode` to True by default. For more information about data sink mode, see [MindSpore doc for data sink](https://www.mindspore.cn/docs/en/master/api_python/mindspore/mindspore.data_sink.html). In data sink mode, `sink_size` is a positive integer or $-1$ (the sink size is same to the number batches in an epoch). Training loss is computed for every `sink_size` batches, and the `max_train_steps` should be no less than `sink_size`. By default, `sink_size` equals to the total number batches in an epoch.
+> - For acceleration, we set the `dataset_sink_mode` to True by default. For more information about data sink mode, see [MindSpore doc for data sink](https://www.mindspore.cn/docs/en/master/api_python/mindspore/mindspore.data_sink.html).
 
 #### Parallel Training
 

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -406,7 +406,7 @@ For the detailed explanations for other arguments, please refer to the document 
 
 > Note:
 > - In Graph mode (default), MindSpore takes about 10~20 mins for graph compilation.
-> - For acceleration, we set the `dataset_sink_mode` to True by default. For more information about data sink mode, see [MindSpore doc for data sink](https://www.mindspore.cn/docs/en/master/api_python/mindspore/mindspore.data_sink.html). In data sink mode, `max_train_steps` should be greater than `sink_size`.
+> - For acceleration, we set the `dataset_sink_mode` to True by default. For more information about data sink mode, see [MindSpore doc for data sink](https://www.mindspore.cn/docs/en/master/api_python/mindspore/mindspore.data_sink.html). In data sink mode, `sink_size` is a positive integer or $-1$ (the sink size is same to the number batches in an epoch). Training loss is computed for every `sink_size` batches, and the `max_train_steps` should be no less than `sink_size`. By default, `sink_size` equals to the total number batches in an epoch.
 
 #### Parallel Training
 

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -416,7 +416,7 @@ Before launching the first-stage training, please make sure you set the three pa
 # start 65x512x512 pretraining, 8 NPUs
 bash scripts/text_condition/train_videoae_65x512x512.sh
 ```
-During training, the training logs will be saved under `parallel_logs/` folder of the specified output directory. The loss values and average per step time will saved under `log/rank_*/result.log`.
+During training, the training logs will be saved under `parallel_logs/` folder of the specified output directory. The loss values and average per step time will saved in `result.log` in the output directory.
 
 After the first-stage training, if using data parallelism (the default parallel mode), the checkpoint files will be saved under `ckpt/` folder. If using optimizer parallelism, there will be multiple checkpoint shards saved in the `ckpt/`. See the following method on how to merge multiple checkpoint shards into a full checkpoint file.
 <details>

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -400,7 +400,7 @@ We use `msrun` to launch the parallel training tasks. For single-node multi-devi
 
 There are some arguments related to the training dataset path:
 - `video_data` or `image_data`: the text file to the video/image dataset. The text file should contain N lines corresponding to N datasets. Each line should have two or three items. If two items are available, they correspond to the video folder and the annotation json file. If three items are available, they correspond to the video folder, the text embedding cache folder, and the annotation json file.
-- `pretrained`: the pretrained checkpoint to be loaded as initial weights before training. if not provided, the LatteT2V will use random initialization.
+- `pretrained`: the pretrained checkpoint to be loaded as initial weights before training. If not provided, the LatteT2V will use random initialization.
 
 For the detailed explanations for other arguments, please refer to the document for [training arguments](docs/training_args.md).
 

--- a/examples/opensora_pku/docs/performance_boosting_history.md
+++ b/examples/opensora_pku/docs/performance_boosting_history.md
@@ -6,7 +6,7 @@ History:
 
 
 - 2024.07.16
-  Major Updates:
+  Major Updates ([PR#596](https://github.com/mindspore-lab/mindone/pull/596)):
   1. Update CANN version ([CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)->[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)) and MindSpore version ([MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) -> [MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/));
   2. Enable optimizer parallelism fusion by default (See `enable_parallel_fusion` in train args);
   3. Change FlashAttention default layout from `BNSD` to `BSH` (See `mindone.models.modules.flash_attention`);

--- a/examples/opensora_pku/docs/performance_boosting_history.md
+++ b/examples/opensora_pku/docs/performance_boosting_history.md
@@ -5,7 +5,7 @@ History:
 
 
 
-- 2024.07.18
+- 2024.07.16
   Major Updates:
   1. Update CANN version ([CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)->[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)) and MindSpore version ([MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) -> [MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/));
   2. Enable optimizer parallelism fusion by default (See `enable_parallel_fusion` in train args);

--- a/examples/opensora_pku/docs/performance_boosting_history.md
+++ b/examples/opensora_pku/docs/performance_boosting_history.md
@@ -1,0 +1,37 @@
+Performance Boosting History
+
+In this doc, we record the performance history of Open-Sora-Plan v1.1.0.
+History:
+
+
+
+- 2024.07.18
+  Major Updates:
+  1. Update CANN version ([CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)->[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)) and MindSpore version ([MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) -> [MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/));
+  2. Enable optimizer parallelism fusion by default (See `enable_parallel_fusion` in train args);
+  3. Change FlashAttention default layout from `BNSD` to `BSH` (See `mindone.models.modules.flash_attention`);
+  4. Set `num_no_recompute` to $4$ in `scripts/text_condition/train_videoae_65x512x512_img16.sh`.
+
+| Model           | Context        | Precision | BS  | NPUs | num_frames + num_images | Resolution  | Train T. (s/step) |
+|:----------------|:---------------|:----------|:---:|:----:|:-----------------------:|:-----------:|:-----------------:|
+| LatteT2V-XL/122 | D910\*-[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)-[MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/) | BF16      |  2  |  8   |         17 + 4          | 512x512     |       2.45        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)-[MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/) | BF16      |  2  |  8   |         65 + 16         | 512x512     |       9.36       |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)-[MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/) | BF16      |  2  |  8   |         65 + 4          | 512x512     |       7.02        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)-[MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/) | BF16      |  1  |  8   |         221 + 4         | 512x512     |       7.18        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)-[MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/) | BF16      |  1  |  8   |         513 + 8         | 512x512     |        12.3       |
+
+> Context: {NPU type}-{CANN version}-{MindSpore version}
+
+- 2024.07.03
+
+Initial performance record:
+
+| Model           | Context        | Precision | BS  | NPUs | num_frames + num_images | Resolution  | Train T. (s/step) |
+|:----------------|:---------------|:----------|:---:|:----:|:-----------------------:|:-----------:|:-----------------:|
+| LatteT2V-XL/122 | D910\*-[CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)-[MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) | BF16      |  2  |  8   |         17 + 4          | 512x512     |       2.54        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)-[MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) | BF16      |  2  |  8   |         65 + 16         | 512x512     |       10.57       |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)-[MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) | BF16      |  2  |  8   |         65 + 4          | 512x512     |       7.50        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)-[MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) | BF16      |  1  |  8   |         221 + 4         | 512x512     |       7.18        |
+| LatteT2V-XL/122 | D910\*-[CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)-[MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) | BF16      |  1  |  8   |         513 + 8         | 512x512     |       12.5        |
+
+> Context: {NPU type}-{CANN version}-{MindSpore version}

--- a/examples/opensora_pku/docs/training_args.md
+++ b/examples/opensora_pku/docs/training_args.md
@@ -1,0 +1,98 @@
+# Training Arguments
+This document includes the training arguments of [`opensora/train/train_t2v.py`](../opensora/train/train_t2v.py).
+
+## Dataset and Pretrained Weights
+
+- `image_data` (type: str, default: None): the path to the image dataset file, e.g., `scripts/train_data/image_data.txt`. If not provided: if `use_image_num` is not zero, `use_img_from_vid` must be True, and the dataset will load images from the video dataset; if `use_image_num` is zero, the model will be trained on video datasets only.
+- `video_data` (type: str, default: None): the path to the video dataset file, e.g., `scripts/train_data/video_data.txt`. It must be provided, and the video dataset file should not be empty.
+- `max_image_size` (type: int, default: 512): the image/frame resolution, which equals to the width and the height.
+- `num_frames` (type: int, default: 17): the number of frames sampled from the video file. It should be an odd integer, e.g., 17 or 65.
+- `use_img_from_vid` (type: bool, default: False): whether to use the non-consecutive frames sampled from videos as images in video-image joint training. If it is False, the images will be sampled from the given image dataset. If it is True, the images will be sampled from videos.
+- `use_image_num` (type: int, default: 0): the number of images sampled from the image dataset. If it is set to an integer greater than zero, it enables video-image-joint training.
+- `text_embed_cache` (type: bool, default: True): whether to use t5 text embedding cache for acceleration. If False, it will extract text embedding on-the-fly during training, and the expected paths in `video_data` and `image_data` should be two: the images/videos folder path and the annotation json file path. If True, the text embedding cache must be extracted ahead, and the expected paths in `video_data` and `image_data` should be three: the images/videos folder path, the text embedding cache folder, and the annotation json file path.
+- `enable_flip` (type: bool, default: False): whether to enable random flip of video frames. This is to avoid motion direction and text mismatch.
+- `model_max_length` (type: int, default: 300): the text embedding length. When `text_embed_cache` is True, `model_max_length` should match with the length of the text embedding cache.
+- `filter_nonexistent` (type: bool, default: True): whether to filter non-existent samples in the dataset.
+- `pretrained` (type: str, default: None): the pretrained checkpoint path to be loaded as initial weight. If not specified, LatteT2V will use random initialization.
+- `text_encoder_name` (type: str, default: "DeepFloyd/t5-v1_1-xxl"): the text encoder name and the path.
+- `ae` (type: str, default: "CausalVAEModel_4x8x8"): the VAE name.
+- `ae_path` (type: str, default: "LanguageBind/Open-Sora-Plan-v1.1.0"): the directory name of VAE.
+- `dataset` (type: str, default: "t2v"): the dataset type.
+
+## LatteT2V Model Definition
+- `use_rope` (type: bool, default: False): whether to use RoPE(Rotary Position Embedding).
+- `compress_kv` (type: bool, default: False): whether to apply KV compression.
+- `compress_kv_factor` (type: int, default: 1): the KV compression factor.
+- `model` (type: str, default: "LatteT2V-XL/122"): the lattet2v model name.
+- `multi_scale` (type: bool, default: False): whether to support multi-scale training. Multi-scale training is not supported now. Working in progress.
+
+## Model Acceleration
+- `enable_flash_attention` (type: bool, default: False): whether to apply Flash-Attention in LatteT2V model. If True, it will save memory.
+- `enable_tiling` (type: bool, default: False): whether to use vae tiling to save memory. If True, it will run vae inference with less memory in a slower speed.
+- `tile_overlap_factor` (type: float, default: 0.25, range: (0, 1)): the overlap factor of vae tiling.
+- `use_recompute` (type: bool, default: False): whether to use recompute (gradient checkpointing) to save memory. If True, will run lattet2v training with less memory in a slower speed.
+- `num_no_recompute` (type: int, default: 0, min: 0): the number of transformer blocks to be removed from the recomputation list if `use_recompute` is True.
+
+## Mixed Precision
+- `precision` (type: str, default: "bf16", choices: ["bf16", "fp16", "fp32"]): the data type for mixed precision configuration of LatteT2V model.
+- `amp_level` (type: str, default: "O1"): mindspore amp level, "O1": most fp32, only layers in whitelist compute in fp16/bf16 (dense, conv, etc), "O2": most fp16 or bf16, only layers in blacklist compute in fp32 (batch norm etc).
+- `text_encoder_precision` (type: str, default: "bf16"): the data type for mixed precision configuration of T5 model.
+- `vae_precision` (type: str, default: "fp16"): the data type for mixed precision configuration of VAE model.
+- `vae_keep_gn_fp32` (type: bool, default: False): whether to put GroupNorm in to the custom fp32 cells list when amp_level is "O2" for VAE model.
+- `loss_scaler_type` (type: str, default: "dynamic"): the loss scaler type. Options: ["dynamic", "static"].
+- `loss_scale_factor`: (type: int, default:2): the loss scale factor. It is only applied when `loss_scaler_type` is dynamic.
+- `scale_window`: (type: int, default:2000): the loss scale change window. It is only applied when `loss_scaler_type` is dynamic.
+- `init_loss_scale` (type: int, default: 65536): the initial value of loss scale. If `loss_scaler_type` is static, the initial value of loss scale will not change. If `loss_scaler_type` is dynamic: if there is no overflow within `scale_window` steps, the loss scale value will be reduced by `loss_scale_factor`; if there is overflow within `scale_window` steps, the loss scale value will be increased by `loss_scale_factor`.
+
+## Dataloader Acceleration
+- `dataset_sink_mode` (type: bool, default: False): whether the dataset should be used in "sink mode". When set to True, the dataset is loaded and sent to NPU devices in parallel which saves loading time.
+- `sink_size` (type: int, default: -1): the size of the dataset sink. If set to -1, the sink size will be equal to the full dataset size.
+- `dataloader_num_workers` (type: int, default: 4): the number of worker processes to use for the data loader.
+- `max_rowsize` (type: int, default: 4): the maximum size of row in MB that is used for shared memory allocation to copy data between processes.
+- `batch_size` (type: int, default: 32): the local training batch size. In parallel training, the global batch size is the product of the local batch size and the number of devices.
+- `dataloader_prefetch_size` (type: int, default: None) : the queue capacity of the thread in pipeline. If provided, the size must be greater than 0, otherwise the queue capacity of the thread is invalid.
+
+## Optimizer
+- `optim` (type: str, default: "adamw"): the optimizer to use for training.
+- `betas` (type: list[float], default: [0.9, 0.999]): the beta1 and beta2 parameters for the AdamW optimizer.
+- `optim_eps` (type: float, default: 1e-8): the epsilon parameter for the AdamW optimizer.
+- `group_strategy` (type: str, default: "norm_and_bias"): the grouping strategy for weight decay. If set to "norm_and_bias", the weight decay filter list includes beta, gamma, and bias parameters. If set to None, the filter list includes layernorm and bias parameters.
+- `clip_grad` (type: bool, default: False): whether to apply gradient clipping during training.
+- `max_grad_norm` (type: float, default: 1.0): the maximum allowed gradient norm when gradient clipping is enabled (i.e., `clip_grad` is True).
+- `use_ema` (type: bool, default: True): whether to use Exponential Moving Average (EMA) of the model parameters during training.
+- `ema_decay` (type: float, default: 0.9999): the decay rate for the Exponential Moving Average (EMA) of the model parameters.
+
+## Learning Rate
+- `gradient_accumulation_steps` (type: int, default: 1): the number of gradient accumulation steps.
+- `weight_decay` (type: float, default: 0.01): the weight decay factor to be used during optimization.
+- `lr_scheduler` (type: str, default: "cosine_decay"): the learning rate scheduler to use during training. Supported values are "constant", "cosine_decay", "polynomial_decay", and "multi_step_decay".
+- `start_learning_rate` (type: float, default: 1e-5): the starting learning rate for the optimizer.
+- `end_learning_rate` (type: float, default: 1e-6): the final learning rate for the optimizer. This is the smallest learning rate during the adjustment for "cosine_decay", "polynomial_decay", and "multi_step_decay" schedulers.
+- `lr_warmup_steps` (type: int, default: 0): the number of warmup steps for the learning rate scheduler.
+- `lr_decay_steps` (type: int, default: 0): the number of steps over which the learning rate will be decayed. This is only applicable when `lr_scheduler` is "cosine_decay" or "polynomial_decay".
+- `scale_lr` (type: bool, default: False): whether to scale the learning rate based on the batch size, gradient accumulation steps, and the number of NPUs/cards used for training.
+
+## MindSpore Envs and Modes
+- `device` (type: str, default: "Ascend"):  the device to be used for training. The options are "Ascend" or "GPU".
+- `max_device_memory` (type: str, default: None): the maximum available device memory, e.g., "30GB" for Ascend 910A or "59GB" for Ascend 910B.
+- `mode` (type: int, default: 0): the execution mode for the model. The options are 0 for graph mode and 1 for pynative mode.
+- `use_parallel` (type: bool, default: False): whether to use parallel processing during training.
+- `parallel_mode` (type: str, default: "data"): the parallel mode to be used when `use_parallel` is True. The options are "data", "optim", and "semi".
+- `seed` (type: int, default: 3407): the random seed for reproducibility.
+- `mempool_block_size` (type: str, default: "9GB"): the size of the memory pool block in PyNative mode or GRAPH_OP_RUN=1 for devices.
+- `optimizer_weight_shard_size` (type: int, default: 8): the size of the communication domain split by the optimizer weight.
+
+## Hyper-Parameters
+- `epochs` (type: int, default: 10): the number of training epochs. It should be a positive integer. If dataset_sink_mode is on, epochs is with respect to dataset sink size. It means the total number of training steps is the product of `epochs` and `sink_size`. Otherwise, it's w.r.t the dataset size, which means the total number of training steps is the product of `epochs` and `num_batches` in an epoch.
+- `step_mode` (type: bool, default: False): whether save ckpt by steps. If False, save ckpt by epochs.
+- `max_train_steps` (type: int, default: None): the maximum number of training steps. If `max_train_steps` is not specified, `epochs` will be the number of epochs, and `step_mode` will be False. If `max_train_steps` is specified, it will overwrite `epochs` to `max_train_steps/num_batches`, and `step_mode` will be True. `max_train_steps` should be greater than the number of batches in an epoch, if provided.
+
+
+## Callbacks and Logging
+- `resume_from_checkpoint` (type: bool, default: False): whether to resume training from `train_resume.ckpt`.
+- `ckpt_save_interval` (type: int, default: 1): the interval of saving checkpoints. If `step_mode` is True, it will save checkpoints every this step number.  If `step_mode` is False, it will save checkpoints every this epoch number.
+- `checkpointing_steps` (type: int, default: None): Save a checkpoint of the training state every X steps. It `checkpointing_steps` is not specified, it will use `ckpt_save_interval` as the checkpoint saving interval. If `checkpointing_steps` is provided, it will overwrite `ckpt_save_interval` to the same value as `checkpointing_steps`, and set `step_mode` to True.
+- `ckpt_max_keep` (type: int, default: 10): the maximum number of checkpoints to keep.
+- `log_level` (type: str, default: logging.INFO): log level, options: logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR.
+- `log_interval` (type: int, default: 1): the log interval. If dataset sink mode is False, the loss will be printed for every X steps. If dataset sink mode is True, the loss will be printed for every `sink_size` steps.
+- `profile` (type: bool, default: False): whether to run profiling for time/speed analysis. The profiling data will saved under `./profile_data`.

--- a/examples/opensora_pku/docs/training_args.md
+++ b/examples/opensora_pku/docs/training_args.md
@@ -83,15 +83,15 @@ This document includes the training arguments of [`opensora/train/train_t2v.py`]
 - `optimizer_weight_shard_size` (type: int, default: 8): the size of the communication domain split by the optimizer weight.
 
 ## Hyper-Parameters
-- `epochs` (type: int, default: 10): the number of training epochs. It should be a positive integer. If dataset_sink_mode is on, epochs is with respect to dataset sink size. It means the total number of training steps is the product of `epochs` and `sink_size`. Otherwise, it's w.r.t the dataset size, which means the total number of training steps is the product of `epochs` and `num_batches` in an epoch.
-- `step_mode` (type: bool, default: False): whether save ckpt by steps. If False, save ckpt by epochs.
 - `max_train_steps` (type: int, default: None): the maximum number of training steps. If `max_train_steps` is not specified, `epochs` will be the number of epochs, and `step_mode` will be False. If `max_train_steps` is specified, it will overwrite `epochs` to `max_train_steps/num_batches`, and `step_mode` will be True. `max_train_steps` should be greater than the number of batches in an epoch, if provided.
+- `epochs` (type: int, default: 10): the number of training epochs. It should be a positive integer. When `max_train_steps` is not provided, the training steps will be `epochs x num_batches`. When `max_train_steps` is provided, the training steps will be `floor(max_train_steps/num_batches) x num_batches`, and `args.epoch` will be overwritten to `floor(max_train_steps/num_batches)`.
+- `step_mode` (type: bool, default: False): whether save ckpt by steps. If False, save ckpt by epochs.
 
 
 ## Callbacks and Logging
 - `resume_from_checkpoint` (type: bool, default: False): whether to resume training from `train_resume.ckpt`.
 - `ckpt_save_interval` (type: int, default: 1): the interval of saving checkpoints. If `step_mode` is True, it will save checkpoints every this step number.  If `step_mode` is False, it will save checkpoints every this epoch number.
-- `checkpointing_steps` (type: int, default: None): Save a checkpoint of the training state every X steps. It `checkpointing_steps` is not specified, it will use `ckpt_save_interval` as the checkpoint saving interval. If `checkpointing_steps` is provided, it will overwrite `ckpt_save_interval` to the same value as `checkpointing_steps`, and set `step_mode` to True.
+- `checkpointing_steps` (type: int, default: None): Save a checkpoint of the training state every X steps. It `checkpointing_steps` is not specified, it will use `ckpt_save_interval` as the checkpoint saving interval (epochs), and set `step_mode` to False. If `checkpointing_steps` is provided, it will overwrite `ckpt_save_interval` to the same value as `checkpointing_steps`, and set `step_mode` to True.
 - `ckpt_max_keep` (type: int, default: 10): the maximum number of checkpoints to keep.
 - `log_level` (type: str, default: logging.INFO): log level, options: logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR.
 - `log_interval` (type: int, default: 1): the log interval. If dataset sink mode is False, the loss will be printed for every X steps. If dataset sink mode is True, the loss will be printed for every `sink_size` steps.

--- a/examples/opensora_pku/opensora/acceleration/communications.py
+++ b/examples/opensora_pku/opensora/acceleration/communications.py
@@ -1,7 +1,11 @@
+import logging
+
 from opensora.acceleration.parallel_states import hccl_info
 
 import mindspore as ms
 from mindspore import Tensor, nn, ops
+
+logger = logging.getLogger(__name__)
 
 
 class _SingleAll2ALL(nn.Cell):
@@ -104,7 +108,7 @@ def prepare_parallel_data(
         # 1. for video states
         padding_needed_v = (sp_size - video_states.shape[2] % sp_size) % sp_size
         if padding_needed_v > 0:
-            print("Doing video padding")
+            logger.debug("Doing video padding")
             # B, C, T, H, W -> B, C, T', H, W
             video_states = ops.pad(video_states, (0, 0, 0, 0, 0, padding_needed_v), mode="constant", value=0)
             video_noise = ops.pad(video_noise, (0, 0, 0, 0, 0, padding_needed_v), mode="constant", value=0)

--- a/examples/opensora_pku/opensora/dataset/image_dataset.py
+++ b/examples/opensora_pku/opensora/dataset/image_dataset.py
@@ -10,7 +10,7 @@ from PIL import Image
 
 import mindspore as ms
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def get_image_path_list(folder):

--- a/examples/opensora_pku/opensora/dataset/t2v_dataset.py
+++ b/examples/opensora_pku/opensora/dataset/t2v_dataset.py
@@ -14,7 +14,7 @@ import mindspore as ms
 
 from .transform import create_video_transforms, t5_text_preprocessing
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TextVideoDataset:

--- a/examples/opensora_pku/opensora/dataset/t2v_dataset.py
+++ b/examples/opensora_pku/opensora/dataset/t2v_dataset.py
@@ -263,7 +263,7 @@ class TextVideoDataset:
             # apply normalization
             pixel_values = (pixel_values / 127.5 - 1.0).astype(np.float32)
 
-        return pixel_values.astype(np.float32), text.astype(np.float32), mask.astype(np.uint8)
+        return pixel_values.astype(np.float32), text.astype(np.float32), mask.astype(np.int32)
 
     def parse_dataset_text(self, text_file):
         with open(text_file, "r") as f:

--- a/examples/opensora_pku/opensora/dataset/t2v_dataset.py
+++ b/examples/opensora_pku/opensora/dataset/t2v_dataset.py
@@ -303,6 +303,7 @@ class TextVideoDataset:
     def get_vid_cap_list(self):
         vid_cap_lists = []
         video_dataset = self.parse_dataset_text(self.video_data)
+        assert len(video_dataset) > 0, f"The video dataset {self.video_data} must not be empty!"
 
         for item in video_dataset:
             anno = item["annotation"]

--- a/examples/opensora_pku/opensora/dataset/text_dataset.py
+++ b/examples/opensora_pku/opensora/dataset/text_dataset.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import mindspore as ms
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TextDataset:

--- a/examples/opensora_pku/opensora/models/ae/videobase/causal_vae/modeling_causalvae.py
+++ b/examples/opensora_pku/opensora/models/ae/videobase/causal_vae/modeling_causalvae.py
@@ -243,8 +243,9 @@ class CausalVAEModel(VideoBaseAE):
         if checkpoint_path is None or len(checkpoint_path) == 0:
             # search for ckpt under pretrained_model_path
             ckpt_paths = glob.glob(os.path.join(pretrained_model_path, "*.ckpt"))
-            assert len(ckpt_paths) == 1, f"Expect to find one checkpoint file under {pretrained_model_path}"
-            f", but found {len(ckpt_paths)} files that end with `.ckpt`"
+            assert (
+                len(ckpt_paths) == 1
+            ), f"Expect to find one checkpoint file under {pretrained_model_path}, but found {len(ckpt_paths)} files that end with `.ckpt`"
             ckpt = ckpt_paths[0]
         else:
             ckpt = checkpoint_path

--- a/examples/opensora_pku/opensora/models/ae/videobase/dataset_videobase.py
+++ b/examples/opensora_pku/opensora/models/ae/videobase/dataset_videobase.py
@@ -14,7 +14,7 @@ from PIL import Image, ImageSequence
 
 import mindspore as ms
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def read_gif(gif_path, mode="RGB"):

--- a/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
+++ b/examples/opensora_pku/opensora/models/diffusion/latte/modeling_latte.py
@@ -569,8 +569,9 @@ class LatteT2V(ModelMixin, ConfigMixin):
         if checkpoint_path is None or len(checkpoint_path) == 0:
             # search for ckpt under pretrained_model_path
             ckpt_paths = glob.glob(os.path.join(pretrained_model_path, "*.ckpt"))
-            assert len(ckpt_paths) == 1, f"Expect to find one checkpoint file under {pretrained_model_path}"
-            f", but found {len(ckpt_paths)} files that end with `.ckpt`"
+            assert (
+                len(ckpt_paths) == 1
+            ), f"Expect to find one checkpoint file under {pretrained_model_path}, but found {len(ckpt_paths)} files that end with `.ckpt`"
             ckpt = ckpt_paths[0]
         else:
             ckpt = checkpoint_path

--- a/examples/opensora_pku/opensora/sample/pipeline_videogen.py
+++ b/examples/opensora_pku/opensora/sample/pipeline_videogen.py
@@ -541,7 +541,7 @@ class VideoGenPipeline(DiffusionPipeline):
         padding_needed = (sp_size - video_states.shape[2] % sp_size) % sp_size
         temp_attention_mask = None
         if padding_needed > 0:
-            print("Doing video padding")
+            logger.debug("Doing video padding")
             # B, C, T, H, W -> B, C, T', H, W
             video_states = ops.pad(video_states, (0, 0, 0, 0, 0, padding_needed), mode="constant", value=0)
 

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -30,6 +30,7 @@ def init_env(
     strategy_ckpt_save_file: str = "",
     optimizer_weight_shard_size: int = 8,
     sp_size: int = 1,
+    enable_parallel_fusion: bool = False,
 ) -> Tuple[int, int, int]:
     """
     Initialize MindSpore environment.
@@ -46,6 +47,8 @@ def init_env(
 
     if max_device_memory is not None:
         ms.set_context(max_device_memory=max_device_memory)
+    if enable_parallel_fusion:
+        ms.set_context(graph_kernel_flags="--enable_parallel_fusion --enable_expand_ops=AdamApplyOneWithDecayAssign")
 
     if distributed:
         ms.set_context(

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -200,8 +200,12 @@ def parse_train_args(parser):
     parser.add_argument("--gradient_accumulation_steps", default=1, type=int, help="gradient accumulation steps")
     parser.add_argument("--weight_decay", default=1e-2, type=float, help="Weight decay.")
     parser.add_argument("--lr_warmup_steps", default=1000, type=int, help="warmup steps")
-    parser.add_argument("--start_learning_rate", default=1e-5, type=float, help="The initial learning rate for Adam.")
-    parser.add_argument("--end_learning_rate", default=1e-7, type=float, help="The end learning rate for Adam.")
+    parser.add_argument(
+        "--start_learning_rate", default=1e-5, type=float, help="The initial learning rate for the optimizer."
+    )
+    parser.add_argument(
+        "--end_learning_rate", default=1e-7, type=float, help="The end learning rate for the optimizer."
+    )
     parser.add_argument("--lr_decay_steps", default=0, type=int, help="lr decay steps.")
     parser.add_argument("--lr_scheduler", default="cosine_decay", type=str, help="scheduler.")
     parser.add_argument(

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -14,7 +14,7 @@ from mindspore.nn.wrap.loss_scale import DynamicLossScaleUpdateCell
 from mindone.utils.config import str2bool
 from mindone.utils.seed import set_random_seed
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def init_env(

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -220,7 +220,7 @@ def parse_train_args(parser):
         "--epochs",
         default=10,
         type=int,
-        help="epochs. If dataset_sink_mode is on, epochs is with respect to dataset sink size. Otherwise, it's w.r.t the dataset size.",
+        help="epochs. When epochs is specified, the total number of training steps = epochs x num_batches",
     )
     parser.add_argument("--dataloader_num_workers", default=12, type=int, help="num workers for dataloder")
     parser.add_argument("--max_rowsize", default=64, type=int, help="max rowsize for data loading")

--- a/examples/opensora_pku/opensora/train/commons.py
+++ b/examples/opensora_pku/opensora/train/commons.py
@@ -24,7 +24,6 @@ def init_env(
     max_device_memory: str = None,
     device_target: str = "Ascend",
     parallel_mode: str = "data",
-    enable_dvm: bool = False,
     mempool_block_size: str = "9GB",
     global_bf16: bool = False,
     strategy_ckpt_save_file: str = "",
@@ -97,9 +96,6 @@ def init_env(
             ascend_config={"precision_mode": "allow_fp32_to_fp16"},  # TODO: tune for better precision
         )
 
-    if enable_dvm:
-        print("enable dvm")
-        ms.set_context(enable_graph_kernel=True, graph_kernel_flags="--disable_cluster_ops=Pow,Select")
     if global_bf16:
         print("Using global bf16")
         ms.set_context(
@@ -149,7 +145,6 @@ def parse_train_args(parser):
         choices=["data", "optim", "semi"],
         help="parallel mode: data, optim",
     )
-    parser.add_argument("--enable_dvm", default=False, type=str2bool, help="enable dvm mode")
     parser.add_argument("--seed", default=3407, type=int, help="data path")
     parser.add_argument(
         "--mempool_block_size",

--- a/examples/opensora_pku/opensora/train/train_causalvae.py
+++ b/examples/opensora_pku/opensora/train/train_causalvae.py
@@ -52,7 +52,7 @@ def main(args):
     )
     if args.exp_name is not None and len(args.exp_name) > 0:
         args.output_dir = os.path.join(args.output_dir, args.exp_name)
-    set_logger(output_dir=args.output_dir, rank=rank_id, log_level=eval(args.log_level))
+    set_logger(name="", output_dir=args.output_dir, rank=rank_id, log_level=eval(args.log_level))
 
     # Load Config
     model_config = os.path.join("opensora/models/ae/videobase/causal_vae/", getae_model_config(args.ae))

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -74,7 +74,7 @@ def main(args):
         optimizer_weight_shard_size=args.optimizer_weight_shard_size,
         sp_size=args.sp_size,
     )
-    set_logger(output_dir=args.output_dir, rank=rank_id, log_level=eval(args.log_level))
+    set_logger(name="", output_dir=args.output_dir, rank=rank_id, log_level=eval(args.log_level))
 
     train_with_vae_latent = args.vae_latent_folder is not None and len(args.vae_latent_folder) > 0
     if train_with_vae_latent:

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -295,18 +295,29 @@ def main(args):
 
     if steps_per_sink == dataset_size:
         logger.info(
-            f"Number of training steps: {total_train_steps}; Number of epochs {args.epochs}; Number of batches in a epoch {dataset_size}"
+            f"Number of training steps: {total_train_steps}; Number of epochs: {args.epochs}; Number of batches in a epoch (dataset_size): {dataset_size}"
         )
-        assert (
-            total_train_steps > 0
-        ), f"Expect that args.epochs x dataset_size > dataset_size, but epochs is {args.epochs} and dataset_size is {dataset_size}."
+        if args.max_train_steps is not None:
+            assert (
+                total_train_steps > 0
+            ), f"Expect that args.max_train_steps > dataset_size, but args.max_train_steps is {args.max_train_steps} and dataset_size is {dataset_size}."
+        else:
+            assert (
+                total_train_steps > 0
+            ), f"Expect that args.epochs x dataset_size > dataset_size, but epochs is {args.epochs} and dataset_size is {dataset_size}."
     else:
         logger.info(
-            f"Number of training steps: {total_train_steps}; Number of sink epochs {sink_epochs}; Number of batches in a sink {steps_per_sink}"
+            f"Number of training steps: {total_train_steps}; Number of sink epochs: {sink_epochs}; Number of batches in a sink (sink_size): {steps_per_sink}"
         )
-        assert (
-            total_train_steps > 0
-        ), f"Expect that total_train_steps > sink size, but max_train_steps is {total_train_steps} and sink size is {steps_per_sink}."
+        if args.max_train_steps is not None:
+            assert (
+                total_train_steps > 0
+            ), f"Expect that args.max_train_steps > sink size, but args.max_train_steps is {args.max_train_steps} and sink size is {steps_per_sink}."
+        else:
+            assert total_train_steps > 0, (
+                f"Expect that args.epochs x dataset_size > sink size, but args.epochs is {args.epochs}, dataset size is {dataset_size},"
+                + f" and sink size is {steps_per_sink}."
+            )
 
     if args.checkpointing_steps is None:
         ckpt_save_interval = args.ckpt_save_interval

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -248,10 +248,17 @@ def main(args):
     assert dataset_size > 0, "Incorrect dataset size. Please check your dataset size and your global batch size"
 
     # 4. build training utils: lr, optim, callbacks, trainer
-    if args.max_train_steps is not None and args.max_train_steps > 0:
+    if args.max_train_steps is not None:
+        assert args.max_train_steps > 0, f"max_train_steps should a positive integer, but got {args.max_train_steps}"
+        assert (
+            args.max_train_steps >= dataset_size
+        ), f"Expect that the max_train_steps is no less than the number of batches, but got {args.max_train_steps} and {dataset_size}"
         args.epochs = args.max_train_steps // dataset_size
         logger.info(f"Forcing training epochs to {args.epochs} when using max_train_steps {args.max_train_steps}")
-    if args.checkpointing_steps is not None and args.checkpointing_steps > 0:
+    if args.checkpointing_steps is not None:
+        assert (
+            args.checkpointing_steps > 0
+        ), f"checkpointing_steps should a positive integer, but got {args.checkpointing_steps}"
         logger.info(f"Saving checkpoints every {args.checkpointing_steps} steps")
         args.step_mode = True
         args.ckpt_save_interval = args.checkpointing_steps
@@ -265,6 +272,9 @@ def main(args):
                 f"Will force decay_steps to be set to 1."
             )
             args.lr_decay_steps = 1
+    assert (
+        args.lr_warmup_steps >= 0
+    ), f"Expect args.lr_warmup_steps to be no less than zero,  but got {args.lr_warmup_steps}"
 
     lr = create_scheduler(
         steps_per_epoch=dataset_size,

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -543,6 +543,9 @@ def parse_t2v_train_args(parser):
         choices=["bf16", "fp16"],
         help="what data type to use for T5 text encoder. Default is `bf16`, which corresponds to ms.bfloat16",
     )
+    parser.add_argument(
+        "--enable_parallel_fusion", default=True, type=str2bool, help="Whether to parallel fusion for AdamW"
+    )
     return parser
 
 

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -76,8 +76,6 @@ def main(args):
         sp_size=args.sp_size,
     )
     set_logger(output_dir=args.output_dir, rank=rank_id, log_level=eval(args.log_level))
-    if args.use_deepspeed:
-        raise NotImplementedError
 
     train_with_vae_latent = args.vae_latent_folder is not None and len(args.vae_latent_folder) > 0
     if train_with_vae_latent:
@@ -458,7 +456,7 @@ def main(args):
 
 def parse_t2v_train_args(parser):
     parser.add_argument("--output_dir", default="outputs/", help="The directory where training results are saved.")
-    parser.add_argument("--dataset", type=str, required=True)
+    parser.add_argument("--dataset", type=str, default="t2v")
     parser.add_argument("--image_data", type=str, required=True)
     parser.add_argument("--video_data", type=str, required=True)
     parser.add_argument(
@@ -474,23 +472,20 @@ def parse_t2v_train_args(parser):
         help="Whether to use T5 embedding cache. Must be provided in image/video_data.",
     )
     parser.add_argument("--vae_latent_folder", default=None, type=str, help="root dir for the vae latent data")
-    parser.add_argument("--model", type=str, default="DiT-XL/122")
-    parser.add_argument("--num_classes", type=int, default=1000)
-    parser.add_argument("--ae", type=str, default="stabilityai/sd-vae-ft-mse")
-    parser.add_argument("--ae_path", type=str, default="stabilityai/sd-vae-ft-mse")
+    parser.add_argument("--model", type=str, default="LatteT2V-XL/122")
+    parser.add_argument("--ae", type=str, default="CausalVAEModel_4x8x8")
+    parser.add_argument("--ae_path", type=str, default="LanguageBind/Open-Sora-Plan-v1.1.0")
 
     parser.add_argument("--num_frames", type=int, default=17)
     parser.add_argument("--max_image_size", type=int, default=512)
     parser.add_argument("--compress_kv", action="store_true")
     parser.add_argument("--compress_kv_factor", type=int, default=1)
     parser.add_argument("--use_rope", action="store_true")
-    parser.add_argument("--attention_mode", type=str, choices=["xformers", "math", "flash"], default="math")
     parser.add_argument("--pretrained", type=str, default=None)
 
     parser.add_argument("--tile_overlap_factor", type=float, default=0.25)
     parser.add_argument("--enable_tiling", action="store_true")
 
-    parser.add_argument("--video_folder", type=str, default="")
     parser.add_argument("--text_encoder_name", type=str, default="DeepFloyd/t5-v1_1-xxl")
     parser.add_argument("--model_max_length", type=int, default=300)
     parser.add_argument("--multi_scale", action="store_true")
@@ -498,7 +493,6 @@ def parse_t2v_train_args(parser):
     # parser.add_argument("--enable_tracker", action="store_true")
     parser.add_argument("--use_image_num", type=int, default=0)
     parser.add_argument("--use_img_from_vid", action="store_true")
-    parser.add_argument("--use_deepspeed", action="store_true")
     parser.add_argument(
         "--max_train_steps",
         type=int,
@@ -514,9 +508,6 @@ def parse_t2v_train_args(parser):
             " checkpoints in case they are better than the last checkpoint, and are also suitable for resuming"
             " training using `--resume_from_checkpoint`."
         ),
-    )
-    parser.add_argument(
-        "--sd_scale_factor", type=float, default=0.18215, help="VAE scale factor of Stable Diffusion model."
     )
 
     parser.add_argument(

--- a/examples/opensora_pku/opensora/train/train_t2v.py
+++ b/examples/opensora_pku/opensora/train/train_t2v.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import sys
 
@@ -278,11 +279,8 @@ def main(args):
 
     if args.max_train_steps is not None:
         assert args.max_train_steps > 0, f"max_train_steps should a positive integer, but got {args.max_train_steps}"
-        assert (
-            args.max_train_steps >= steps_per_sink
-        ), f"Expect that the max_train_steps is no less than {steps_per_sink}, but got {args.max_train_steps}"
         total_train_steps = args.max_train_steps
-        args.epochs = total_train_steps // dataset_size
+        args.epochs = math.ceil(total_train_steps / dataset_size)
     else:
         # use args.epochs
         assert (
@@ -290,34 +288,17 @@ def main(args):
         ), f"When args.max_train_steps is not provided, args.epochs must be a positive integer! but got {args.epochs}"
         total_train_steps = args.epochs * dataset_size
 
-    sink_epochs = total_train_steps // steps_per_sink
+    sink_epochs = math.ceil(total_train_steps / steps_per_sink)
     total_train_steps = sink_epochs * steps_per_sink
 
     if steps_per_sink == dataset_size:
         logger.info(
             f"Number of training steps: {total_train_steps}; Number of epochs: {args.epochs}; Number of batches in a epoch (dataset_size): {dataset_size}"
         )
-        if args.max_train_steps is not None:
-            assert (
-                total_train_steps > 0
-            ), f"Expect that args.max_train_steps > dataset_size, but args.max_train_steps is {args.max_train_steps} and dataset_size is {dataset_size}."
-        else:
-            assert (
-                total_train_steps > 0
-            ), f"Expect that args.epochs x dataset_size > dataset_size, but epochs is {args.epochs} and dataset_size is {dataset_size}."
     else:
         logger.info(
             f"Number of training steps: {total_train_steps}; Number of sink epochs: {sink_epochs}; Number of batches in a sink (sink_size): {steps_per_sink}"
         )
-        if args.max_train_steps is not None:
-            assert (
-                total_train_steps > 0
-            ), f"Expect that args.max_train_steps > sink size, but args.max_train_steps is {args.max_train_steps} and sink size is {steps_per_sink}."
-        else:
-            assert total_train_steps > 0, (
-                f"Expect that args.epochs x dataset_size > sink size, but args.epochs is {args.epochs}, dataset size is {dataset_size},"
-                + f" and sink size is {steps_per_sink}."
-            )
 
     if args.checkpointing_steps is None:
         ckpt_save_interval = args.ckpt_save_interval

--- a/examples/opensora_pku/requirements.txt
+++ b/examples/opensora_pku/requirements.txt
@@ -18,4 +18,5 @@ tokenizers>=0.15.2
 sentencepiece
 transformers>=4.39.3
 pyav
+bs4
 huggingface_hub>=0.22.2

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_17x512x512.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_17x512x512.sh
@@ -45,3 +45,4 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
       --use_parallel True \
       --parallel_mode "data" \
       --num_no_recompute 18 \
+      --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_221x512x512_sp.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_221x512x512_sp.sh
@@ -46,4 +46,5 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --use_parallel True \
     --parallel_mode "data" \
     --sp_size 8 \
-    --max_device_memory 59GB
+    --max_device_memory 59GB \
+    --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_513x512x512_sp.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_513x512x512_sp.sh
@@ -47,4 +47,5 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --use_parallel True \
     --parallel_mode "data" \
     --sp_size 8 \
-    --max_device_memory 59GB
+    --max_device_memory 59GB \
+    --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512.sh
@@ -46,3 +46,4 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
       --use_parallel True \
       --parallel_mode "data" \
       --num_no_recompute 6 \
+      --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
@@ -3,7 +3,7 @@ export MS_ENABLE_NUMA=0
 export MS_MEMORY_STATISTIC=1
 export GLOG_v=2
 
-export HCCL_BUFFSIZE=1 # reduce memory consumption when dataset_sink_mode=True, may degrade speed
+# export HCCL_BUFFSIZE=1 # reduce memory consumption when dataset_sink_mode=True, may degrade speed
 export MS_DATASET_SINK_QUEUE=2 # reduce memory consumption when dataset_sink_mode=True, may degrade speed
 # hyper-parameters
 image_size=512  # the image size of frames, same to image height and image width

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
@@ -48,3 +48,4 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
       --use_parallel True \
       --parallel_mode "data" \
       --max_device_memory "59GB" \
+      --num_no_recompute 4 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_img16.sh
@@ -49,3 +49,4 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
       --parallel_mode "data" \
       --max_device_memory "59GB" \
       --num_no_recompute 4 \
+      --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
@@ -1,4 +1,4 @@
-export DEVICE_ID=0
+export DEVICE_ID=0  # an integer within [0, 7], change it to set the device ID
 export MS_ENABLE_NUMA=0
 export MS_MEMORY_STATISTIC=1
 export GLOG_v=2

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
@@ -44,3 +44,4 @@ python opensora/train/train_t2v.py \
       --use_recompute True \
       --dataset_sink_mode True \
       --num_no_recompute 6 \
+      --sink_size -1 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
@@ -1,0 +1,45 @@
+export MS_ENABLE_NUMA=0
+export MS_MEMORY_STATISTIC=1
+export GLOG_v=2
+
+# hyper-parameters
+image_size=512  # the image size of frames, same to image height and image width
+use_image_num=4  # to include n number of images in an input sample
+num_frames=65  # to sample m frames from a single video. The total number of images： num_frames + use_image_num
+model_dtype="bf16" # the data type used for mixed precision of the diffusion transformer model (LatteT2V).
+amp_level="O2" # the default auto mixed precision level for LatteT2V.
+enable_flash_attention="True" # whether to use MindSpore Flash Attention
+batch_size=2 # training batch size
+lr="2e-05" # learning rate. Default learning schedule is constant
+output_dir=t2v-f$num_frames-$image_size-img$use_image_num-videovae488-$model_dtype-FA$enable_flash_attention-bs$batch_size-t5
+
+python opensora/train/train_t2v.py \
+    --pretrained LanguageBind/Open-Sora-Plan-v1.1.0/t2v.ckpt \
+    --model LatteT2V-XL/122 \
+    --text_encoder_name DeepFloyd/t5-v1_1-xxl \
+    --dataset t2v \
+    --ae CausalVAEModel_4x8x8 \
+    --ae_path LanguageBind/Open-Sora-Plan-v1.1.0 \
+    --video_data "scripts/train_data/video_data.txt" \
+    --image_data "scripts/train_data/image_data.txt" \
+    --num_frames $num_frames \
+    --max_image_size $image_size \
+    --enable_flash_attention $enable_flash_attention \
+    --batch_size=$batch_size \
+    --dataloader_num_workers 10 \
+    --gradient_accumulation_steps=1 \
+    --max_train_steps=1000000 \
+    --start_learning_rate=$lr \
+    --lr_scheduler="constant" \
+    --lr_warmup_steps=0 \
+    --precision=$model_dtype \
+    --amp_level=$amp_level \
+    --checkpointing_steps=500 \
+    --output_dir=$output_dir \
+    --model_max_length 300 \
+    --clip_grad True \
+    --use_image_num $use_image_num \
+    --enable_tiling \
+      --use_recompute True \
+      --dataset_sink_mode True \
+      --num_no_recompute 6 \

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_single_device.sh
@@ -1,3 +1,4 @@
+export DEVICE_ID=0
 export MS_ENABLE_NUMA=0
 export MS_MEMORY_STATISTIC=1
 export GLOG_v=2

--- a/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_sp.sh
+++ b/examples/opensora_pku/scripts/text_condition/train_videoae_65x512x512_sp.sh
@@ -46,4 +46,5 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --use_parallel True \
     --parallel_mode "data" \
     --sp_size 8 \
-    --max_device_memory 59GB
+    --max_device_memory 59GB \
+    --sink_size -1 \


### PR DESCRIPTION
To accelerate training speed, major changes are made:
  1. Update CANN version ([CANN C18(0517)](https://repo.mindspore.cn/ascend/ascend910/20240517/)->[CANN C18(0705)](https://repo.mindspore.cn/ascend/ascend910/20240705/)) and MindSpore version ([MS2.3_master(0615)](https://repo.mindspore.cn/mindspore/mindspore/version/202406/20240615/master_20240615020018_43ccb91e45899b64fe31d304497ab17e3ada3cea_newest/unified/) -> [MS2.3_master(0705)](https://repo.mindspore.cn/mindspore/mindspore/version/202407/20240705/master_20240705220018_51f414917fd9a312dd43ea62eea61cf37c3dfbd6_newest/unified/)); inference results on the new versions are visually fine. The overfitting experiment generates reasonable results.
  2. Enable optimizer parallelism fusion by default (See `enable_parallel_fusion` in train args);
  3. Change FlashAttention default layout from `BNSD` to `BSH` (See `mindone.models.modules.flash_attention`);
  4. Set `num_no_recompute` to $4$ in `scripts/text_condition/train_videoae_65x512x512_img16.sh`.

Minor changes are also made to:
1. `train_t2v.py`: added some arguments assertions to ensure the input arguments are valid;
2. `t2v_dataset.py`: change the mask dtype from uint8 to int32, because cann 0705 does not support tiling with uint8 tensors.
3. `README.md`: include two more documents (performance boosting history and training args) to enhance users' understanding; include a single-device training script `train_videoae_65x512x512_single_device.sh` as an example.