### PR TITLE
[OpenSora v1.1] fix input sequence size

### DIFF
--- a/examples/opensora_hpcai/scripts/inference.py
+++ b/examples/opensora_hpcai/scripts/inference.py
@@ -243,7 +243,7 @@ def main(args):
 
     elif args.model_version == "v1.1":
         model_name = "STDiT2"
-        model_extra_args["qk_norm"] = True
+        model_extra_args.update({"input_sq_size": 512, "qk_norm": True})
         logger.info(f"{model_name} init")
         latte_model = STDiT2_XL_2(**model_extra_args)
     elif args.model_version == "v1.2":

--- a/examples/opensora_hpcai/scripts/train.py
+++ b/examples/opensora_hpcai/scripts/train.py
@@ -417,7 +417,7 @@ def main(args):
         latte_model = STDiT_XL_2(**model_extra_args)
     elif args.model_version == "v1.1":
         model_name = "STDiT2"
-        model_extra_args["qk_norm"] = True
+        model_extra_args.update({"input_sq_size": 512, "qk_norm": True})
         latte_model = STDiT2_XL_2(**model_extra_args)
     elif args.model_version == "v1.2":
         model_name = "STDiT3"


### PR DESCRIPTION
During code refactoring for OpenSora v1.2, the `input_sq_size` argument for OS v1.1 was mistakenly removed (#561 #579). This PR fixes this issue.