### PR TITLE
[OpenSora-hpcai] OSv1.2 performance optimization

### DIFF
--- a/examples/opensora_hpcai/opensora/models/layers/operation_selector.py
+++ b/examples/opensora_hpcai/opensora/models/layers/operation_selector.py
@@ -56,9 +56,7 @@ def get_repeat_interleave_op():
         # provide better performance for static shape in graph mode
         return ops.repeat_interleave
     else:
-        # FIXME: check overflow for v2
-        # return repeat_interleave_ext_v2
-        return repeat_interleave_ext
+        return repeat_interleave_ext_v2
 
 
 def get_chunk_op():

--- a/examples/opensora_hpcai/opensora/models/layers/rotary_embedding.py
+++ b/examples/opensora_hpcai/opensora/models/layers/rotary_embedding.py
@@ -28,7 +28,7 @@ def rotate_half(x: Tensor) -> Tensor:
 def apply_rotary_emb(freqs: Parameter, t: Tensor, scale: float = 1.0, seq_dim: int = -2) -> Tensor:
     # FIXME: start_index is always 0 in OS1.2 and ops.concat doesn't support empty elements. OS1.x future versions may need start_index > 0
     # t, t_right = t[..., start_index:end_index], t[..., end_index:]
-    t = (t * freqs.cos().astype(t.dtype) * scale) + (rotate_half(t) * freqs.sin().astype(t.dtype) * scale)
+    t = (t * freqs.cos() * scale) + (rotate_half(t) * freqs.sin() * scale)
 
     return t
 
@@ -139,7 +139,7 @@ class RotaryEmbedding(nn.Cell):
         raise NotImplementedError
 
     def construct(self, t: Tensor, seq_len=None, offset=0) -> Tensor:
-        freqs = t.astype(self.freqs.dtype)[..., None] * self.freqs
+        freqs = t[..., None] * self.freqs.to(t.dtype)
         return self.repeat_interleave(freqs, 2, -1)  # ... n -> ... (n r), r = 2
 
 

--- a/examples/opensora_hpcai/opensora/models/stdit/stdit3.py
+++ b/examples/opensora_hpcai/opensora/models/stdit/stdit3.py
@@ -101,13 +101,14 @@ class STDiT3Block(nn.Cell):
     ) -> Tensor:
         # prepare modulate parameters
         B, N, C = x.shape
+        scale_shift_table = self.scale_shift_table.to(x.dtype)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.chunk(
-            self.scale_shift_table[None] + t.reshape(B, 6, -1), 6, 1
+            scale_shift_table[None] + t.reshape(B, 6, -1), 6, 1
         )
 
         # frames mask branch
         shift_msa_zero, scale_msa_zero, gate_msa_zero, shift_mlp_zero, scale_mlp_zero, gate_mlp_zero = self.chunk(
-            self.scale_shift_table[None] + t0.reshape(B, 6, -1), 6, 1
+            scale_shift_table[None] + t0.reshape(B, 6, -1), 6, 1
         )
 
         # modulate (attention)

--- a/examples/opensora_hpcai/opensora/models/vae/vae.py
+++ b/examples/opensora_hpcai/opensora/models/vae/vae.py
@@ -110,11 +110,8 @@ class VideoAutoencoderKL(nn.Cell):
 
     @staticmethod
     def rearrange_in(x):
-        B, C, T, H, W = x.shape
-        # (b c t h w) -> (b t c h w)
-        x = ops.transpose(x, (0, 2, 1, 3, 4))
+        B, T, C, H, W = x.shape
         x = ops.reshape(x, (B * T, C, H, W))
-
         return x
 
     @staticmethod

--- a/examples/opensora_hpcai/opensora/pipelines/train_pipeline.py
+++ b/examples/opensora_hpcai/opensora/pipelines/train_pipeline.py
@@ -145,11 +145,10 @@ class DiffusionWithLoss(nn.Cell):
         print("x shape", x.shape)
         with no_grad():
             # 1. get image/video latents z using vae
-            # (b f c h w) -> (b c f h w)
-            x = ops.transpose(x, (0, 2, 1, 3, 4))
-
             if not self.video_emb_cached:
                 x = self.get_latents(x)
+            else:
+                x = ops.transpose(x, (0, 2, 1, 3, 4))
 
             # 2. get conditions
             if not self.text_emb_cached:

--- a/examples/opensora_hpcai/opensora/utils/model_utils.py
+++ b/examples/opensora_hpcai/opensora/utils/model_utils.py
@@ -9,13 +9,11 @@ from mindspore.train.callback import _CallbackManager
 from ..models.layers.blocks import Attention, LayerNorm, LlamaRMSNorm, PositionEmbedding2D, SinusoidalEmbedding
 from ..models.text_encoder.flan_t5_large.t5 import T5LayerNorm
 
-# SORA's whitelist (FP32) operators
-WHITELIST_OPS = [
+# SORA's blacklist (FP32) operators for O2 AMP level
+BLACKLIST_OPS = [
     LayerNorm,
     Attention,
     LlamaRMSNorm,
-    SiLU,
-    GELU,
     GroupNorm,
     PositionEmbedding2D,
     SinusoidalEmbedding,

--- a/examples/opensora_hpcai/scripts/inference.py
+++ b/examples/opensora_hpcai/scripts/inference.py
@@ -26,7 +26,7 @@ from opensora.models.vae.vae import SD_CONFIG, OpenSoraVAE_V1_2, VideoAutoencode
 from opensora.pipelines import InferPipeline, InferPipelineFiTLike
 from opensora.utils.amp import auto_mixed_precision
 from opensora.utils.cond_data import get_references, read_captions_from_csv, read_captions_from_txt
-from opensora.utils.model_utils import WHITELIST_OPS, _check_cfgs_in_parser, str2bool
+from opensora.utils.model_utils import BLACKLIST_OPS, _check_cfgs_in_parser, str2bool
 from opensora.utils.util import IMG_FPS, apply_mask_strategy, process_mask_strategies, process_prompts
 
 from mindone.data.data_split import distribute_samples
@@ -269,7 +269,7 @@ def main(args):
 
     if args.dtype in ["fp16", "bf16"]:
         latte_model = auto_mixed_precision(
-            latte_model, amp_level=args.amp_level, dtype=dtype_map[args.dtype], custom_fp32_cells=WHITELIST_OPS
+            latte_model, amp_level=args.amp_level, dtype=dtype_map[args.dtype], custom_fp32_cells=BLACKLIST_OPS
         )
 
     if args.ckpt_path:
@@ -297,7 +297,7 @@ def main(args):
                     "T5 dtype is fp16, which may lead to video color vibration. Suggest to use bf16 or fp32."
                 )
             text_encoder = auto_mixed_precision(
-                text_encoder, amp_level="O2", dtype=dtype_map[args.t5_dtype], custom_fp32_cells=WHITELIST_OPS
+                text_encoder, amp_level="O2", dtype=dtype_map[args.t5_dtype], custom_fp32_cells=BLACKLIST_OPS
             )
         logger.info(f"Num tokens: {mask.asnumpy().sum(2)}")
     else:

--- a/examples/opensora_hpcai/scripts/train.py
+++ b/examples/opensora_hpcai/scripts/train.py
@@ -39,7 +39,7 @@ from opensora.utils.amp import auto_mixed_precision
 from opensora.utils.callbacks import EMAEvalSwapCallback, PerfRecorderCallback
 from opensora.utils.ema import EMA, save_ema_ckpts
 from opensora.utils.metrics import BucketLoss
-from opensora.utils.model_utils import WHITELIST_OPS, Model
+from opensora.utils.model_utils import BLACKLIST_OPS, Model
 from opensora.utils.resume import flush_from_cache, get_resume_ckpt, get_resume_states, resume_train_net, save_train_net
 
 from mindone.trainers.callback import EvalSaveCallback, OverflowMonitor, ProfilerCallbackEpoch, StopAtStepCallback
@@ -466,7 +466,7 @@ def main(args):
                 latte_model,
                 amp_level=args.amp_level,
                 dtype=dtype_map[args.dtype],
-                custom_fp32_cells=WHITELIST_OPS,
+                custom_fp32_cells=BLACKLIST_OPS,
             )
     # load checkpoint
     if len(args.pretrained_model_path) > 0:

--- a/examples/opensora_hpcai/tests/test_stdit3_sequence_parallelism.py
+++ b/examples/opensora_hpcai/tests/test_stdit3_sequence_parallelism.py
@@ -4,7 +4,7 @@ import numpy as np
 from opensora.acceleration.parallel_states import create_parallel_group, get_sequence_parallel_group
 from opensora.models.stdit.stdit3 import STDiT3
 from opensora.utils.amp import auto_mixed_precision
-from opensora.utils.model_utils import WHITELIST_OPS
+from opensora.utils.model_utils import BLACKLIST_OPS
 
 import mindspore as ms
 import mindspore.nn as nn
@@ -82,7 +82,7 @@ def run_model(mode: int = 0, model_dtype: ms.dtype = ms.float32):
             non_dist_model,
             amp_level="O2",
             dtype=model_dtype,
-            custom_fp32_cells=WHITELIST_OPS,
+            custom_fp32_cells=BLACKLIST_OPS,
         )
 
     # sequence parallel model
@@ -95,7 +95,7 @@ def run_model(mode: int = 0, model_dtype: ms.dtype = ms.float32):
             dist_model,
             amp_level="O2",
             dtype=model_dtype,
-            custom_fp32_cells=WHITELIST_OPS,
+            custom_fp32_cells=BLACKLIST_OPS,
         )
 
     for (_, w0), (_, w1) in zip(non_dist_model.parameters_and_names(), dist_model.parameters_and_names()):

--- a/examples/opensora_hpcai/tests/test_vae_1_2_parallelism.py
+++ b/examples/opensora_hpcai/tests/test_vae_1_2_parallelism.py
@@ -4,7 +4,7 @@ import numpy as np
 from opensora.acceleration.parallel_states import create_parallel_group
 from opensora.models.vae.vae import OpenSoraVAE_V1_2
 from opensora.utils.amp import auto_mixed_precision
-from opensora.utils.model_utils import WHITELIST_OPS
+from opensora.utils.model_utils import BLACKLIST_OPS
 
 import mindspore as ms
 import mindspore.nn as nn
@@ -58,7 +58,7 @@ def run_model(mode: int = 0, model_dtype: ms.dtype = ms.float16):
             non_dist_model,
             amp_level="O2",
             dtype=model_dtype,
-            custom_fp32_cells=WHITELIST_OPS,
+            custom_fp32_cells=BLACKLIST_OPS,
         )
     non_dist_model.set_train(False)
 
@@ -72,7 +72,7 @@ def run_model(mode: int = 0, model_dtype: ms.dtype = ms.float16):
             dist_model,
             amp_level="O2",
             dtype=model_dtype,
-            custom_fp32_cells=WHITELIST_OPS,
+            custom_fp32_cells=BLACKLIST_OPS,
         )
     dist_model.set_train(False)
 

--- a/mindone/trainers/callback.py
+++ b/mindone/trainers/callback.py
@@ -355,10 +355,12 @@ class ProfilerCallback(ms.Callback):
         cur_step = cb_params.cur_step_num
         if cur_step == self.end_step:
             self.profiler.stop()
-            self.profiler.analyse()
-            _logger.info(f"finish analyzing profiler in step range [{self.start_step}, {self.end_step}]")
+            _logger.info(f"Finished profiling in step range [{self.start_step}, {self.end_step}]")
             if self.exit_after_analyze:
                 run_context.request_stop()
+
+    def on_train_end(self, run_context):
+        self.profiler.analyse()
 
 
 class ProfilerCallbackEpoch(ms.Callback):
@@ -379,4 +381,6 @@ class ProfilerCallbackEpoch(ms.Callback):
         epoch_num = cb_params.cur_epoch_num
         if epoch_num == self.stop_epoch:
             self.profiler.stop()
-            self.profiler.analyse()
+
+    def on_train_end(self, run_context):
+        self.profiler.analyse()


### PR DESCRIPTION
TODO:
- Validate accuracy and visual quality on long training.
- Update performance tables in README.

Tests were conducted in dynamic DVM mode, on MS daily from 09.04 with CANN 8.0 RC2. Results include training step average time only (no data loading time):
| Changes                                 | Shape (res x frames x batch) | Time (s) | Change (s)     | Comment                              |
|-----------------------------------------|------------------------------|----------|----------------|--------------------------------------|
| Original                                | 720p x 51 x 2                | 30.409   |                |                                      |
|                                         | 144p x 204 x 10              | 19.934   |                |                                      |
| Switch to `repeat_interleave_ext_v2`    | 720p x 51 x 2                | 28.913   | -1.496 (-4.9%) |                                      |
|                                         | 144p x 204 x 10              | 19.872   | -0.062 (-0.3%) |                                      |
| Remove SiLU & GELU FP32 upcast          | 720p x 51 x 2                | 30.346   | -0.062 (-0.2%) | No performance improvement,          |
|                                         | 144p x 204 x 10              | 20.506   | +0.572 (+2.9%) | will consult with the MS team.       |
| Convert parameters to BF16              | 720p x 51 x 2                | 28.957   | -1.452 (-4.8%) |                                      |
|                                         | 144p x 204 x 10              | 18.747   | -1.187 (-3.9%) |                                      |
| Remove redundant `ops.transpose` in VAE | 720p x 51 x 2                | 30.448   | +0.040 (+0.1%) | No changes due to the kernel fusion. |
|                                         | 144p x 204 x 10              | 20.103   | +0.168 (+0.8%) | Beneficial in KBK & PyNative modes.  |
|                                         |                              |          |                |                                      |
| **Final improvement**                   | 720p x 51 x 2                | 27.896   | -2.512 (-8.3%) |                                      |
|                                         | 144p x 204 x 10              | 18.804   | -1.130 (-5.7%) |                                      |
