### PR TITLE
Support update MindSpore version on the fly in cloud training launch

### DIFF
--- a/tools/modelarts/README.md
+++ b/tools/modelarts/README.md
@@ -19,7 +19,8 @@ python $MA_JOB_DIR/mindone/tools/modelarts/msrun/msrun.py mindone/examples/opens
 
 ⚠️ Note:
 - `$output_path` should be an **ABSOLUTE** path.
-- if no `$output_path`, the msrun logs will be saved at the ModelArts default output directory: `/home/ma-user/modelarts/outputs/output_path_0/`.
+- If no `$output_path`, the msrun logs will be saved at the ModelArts default output directory: `/home/ma-user/modelarts/outputs/output_path_0/`.
+- If you want to update MindSpore version before the training starts, please `export ms_whl=[PATH_TO_MINDSPORE_WHL_FILE]`, and check the log to confirm whether the MindSpore is updated successfully.
 
 ## Launch with rank table
 Refer to [here](https://support.huaweicloud.com/bestpractice-modelarts/develop-modelarts-0120.html).

--- a/tools/modelarts/msrun/run_train_modelarts.sh
+++ b/tools/modelarts/msrun/run_train_modelarts.sh
@@ -38,6 +38,15 @@ unset RANK_ID
 # fi
 
 
+if [ -z "${ms_whl}" ]; then
+    echo "Keep MindSpore version unchanged in the docker container."
+else
+    echo "Updating MindSpore version from ${ms_whl}..."
+    pip uninstall -y mindspore
+    pip install ${ms_whl}/mindspore-*.whl
+fi
+
+
 if [ -z "${output_path}" ]; then
     log_root_dir="/home/ma-user/modelarts/outputs/output_path_0"  # no $output_path , set to ModelArts default output directory
 else


### PR DESCRIPTION
Adds # (feature)

In cloud training launched by `msrun`, if the MindSpore needs to be updated, users can `export ms_whl=[PATH_TO_MINDSPORE_WHL_FILE]` without rebuilding and uploading the whole docker again.