### PR TITLE
[Open-Sora-Plan-v1.2.0]: VAE training update

### DIFF
--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -341,10 +341,10 @@ Runing this command will generate reconstructed videos under the given `output_g
 
 Here, we report the training performance and evaluation results on the UCF-101 dataset. Experiments are tested on Ascend 910* with mindspore 2.3.1 graph mode.
 
-| model name  | cards  |  batch size | resolution | graph compile | precision | discriminator |sink | jit level| s/step | img/s  | psnr | ssim  |
-|:-----------|:------ |:-----------:|:----------:|:-------------:|:----------:|:------------:|:---:|:--------:|--------:|------:|:----:|-------:|
-| CausalVAE  |  8     |       1    |  9x256x256  |     3 mins   |   FP32     |    TRUE      | OFF  |    O0   |    2.04   |  35.29 |  29.30 |   0.88    |
-| CausalVAE  |  8    |       1     | 25x256x256  |    3 mins   |   BF16     |     FALSE    |  OFF |     O0  |     4.21   |  47.51 | 28.92 |    0.87    |
+| model name  | cards  |  graph compile | batch size | Resolution(framesxHxW) | Precision | Discriminator |data sink | jit level| Train T. (s/step) | PSNR | SSIM  |
+|:-----------|:------ |:---------------:|:----------:|:---------------------:|:----------:|:-------------:|:--------:|:-------:|-------------------:|:----:|-------:|
+| CausalVAE  |  8     |       3mins    |     1x8      |           9x256x256    |   FP32     |    TRUE      |    FALSE |     O0   |    2.04           |  29.30 |   0.88      |
+| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   BF16     |     FALSE    |    FALSE |     O0  |     4.21           | 28.92 |    0.87     |
 
 
 

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -341,11 +341,11 @@ Runing this command will generate reconstructed videos under the given `output_g
 
 Here, we report the training performance and evaluation results on the UCF-101 dataset. Experiments are tested on Ascend 910* with mindspore 2.3.1 graph mode.
 
-| model name  | cards  |  graph compile | batch size | Resolution(framesxHxW) | Precision | Discriminator |data sink | jit level| Train T. (s/step) | PSNR | SSIM  | num train steps|
-|:-----------|:------ |:---------------:|:----------:|:---------------------:|:----------:|:-------------:|:--------:|:-------:|-------------------:|:----:|-------:|:----:|
-| CausalVAE  |  8     |       3mins    |     1x8      |           9x256x256    |   FP32     |    TRUE      |    FALSE |     O0   |    2.04           |  29.30 |   0.88      |  40k |
-| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   BF16     |     FALSE    |    FALSE |     O0  |     4.21           | 28.92 |    0.87     |   24k |
-| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   FP32     |     TRUE    |    FALSE |     O0  |      5.45     |  29.28 |   0.88   |  40k |
+| model name  | cards  |  batch size | resolution | graph compile | precision | discriminator |sink | jit level| s/step | img/s  | psnr | ssim  | train steps|
+|:-----------|:------ |:-----------:|:----------:|:-------------:|:----------:|:------------:|:---:|:--------:|--------:|------:|:----:|-------:|-------:|
+| CausalVAE  |  8     |       1    |  9x256x256  |     3 mins   |   FP32     |    TRUE      | OFF  |    O0   |    2.04   |  35.29 |  29.30 |   0.88    | 40k |
+| CausalVAE  |  8    |       1     | 25x256x256  |    3 mins   |   BF16     |     FALSE    |  OFF |     O0  |     4.21   |  47.51 | 28.92 |    0.87    | 24k |
+| CausalVAE  |  8    |      1      |  25x256x256   |   3 mins   | FP32       |     TRUE    |  OFF |     O0  |   5.45 |   36.70  | 29.28 |   0.88   |  40k |
 
 
 ### Training Diffusion Model

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -341,11 +341,10 @@ Runing this command will generate reconstructed videos under the given `output_g
 
 Here, we report the training performance and evaluation results on the UCF-101 dataset. Experiments are tested on Ascend 910* with mindspore 2.3.1 graph mode.
 
-| model name  | cards  |  batch size | resolution | graph compile | precision | discriminator |sink | jit level| s/step | img/s  | psnr | ssim  | train steps|
+| model name  | cards  |  batch size | resolution | graph compile | precision | discriminator |sink | jit level| s/step | img/s  | psnr | ssim  | recipe|
 |:-----------|:------ |:-----------:|:----------:|:-------------:|:----------:|:------------:|:---:|:--------:|--------:|------:|:----:|-------:|-------:|
-| CausalVAE  |  8     |       1    |  9x256x256  |     3 mins   |   FP32     |    TRUE      | OFF  |    O0   |    2.04   |  35.29 |  29.30 |   0.88    | 40k |
-| CausalVAE  |  8    |       1     | 25x256x256  |    3 mins   |   BF16     |     FALSE    |  OFF |     O0  |     4.21   |  47.51 | 28.92 |    0.87    | 24k |
-| CausalVAE  |  8    |      1      |  25x256x256   |   3 mins   | FP32       |     TRUE    |  OFF |     O0  |   5.45 |   36.70  | 29.28 |   0.88   |  40k |
+| CausalVAE  |  8    |       1     | 25x256x256  |    3 mins   |   BF16     |     FALSE    |  OFF |     O0  |     4.21   |  47.51 | 28.92 |    0.87    | [train](./scripts/causalvae/train_without_gan_loss_multi_device.sh) |
+| CausalVAE  |  8    |      1      | 25x256x256  |   3 mins    |   FP32     |     TRUE     |  OFF |     O0  |   5.45 |   36.70  | 29.28 |   0.88   |  [train](./scripts/causalvae/train_with_gan_loss_multi_device.sh) |
 
 
 ### Training Diffusion Model

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -341,10 +341,10 @@ Runing this command will generate reconstructed videos under the given `output_g
 
 Here, we report the training performance and evaluation results on the UCF-101 dataset. Experiments are tested on Ascend 910* with mindspore 2.3.1 graph mode.
 
-| model name  | cards  |  batch size | resolution | graph compile | precision | discriminator |sink | jit level| s/step | img/s  | psnr | ssim  | recipe|
-|:-----------|:------ |:-----------:|:----------:|:-------------:|:----------:|:------------:|:---:|:--------:|--------:|------:|:----:|-------:|-------:|
-| CausalVAE  |  8    |       1     | 25x256x256  |    3 mins   |   BF16     |     FALSE    |  OFF |     O0  |     4.21   |  47.51 | 28.92 |    0.87    | [train](./scripts/causalvae/train_without_gan_loss_multi_device.sh) |
-| CausalVAE  |  8    |      1      | 25x256x256  |   3 mins    |   FP32     |     TRUE     |  OFF |     O0  |   5.45 |   36.70  | 29.28 |   0.88   |  [train](./scripts/causalvae/train_with_gan_loss_multi_device.sh) |
+| model name  | cards  |  batch size | resolution | precision | discriminator |sink |recompute| jit level|  graph compile | s/step | img/s  | psnr | ssim  | recipe|
+|:-----------|:------ |:-----------:|:----------:|:-------------:|:----------:|:------------:|:---:|:--------:|:--------:|--------:|------:|:----:|-------:|-------:|
+| CausalVAE  |  8    |       1     | 25x256x256  |     BF16     |     FALSE    |  OFF |    OFF |    O0  |  3 mins   |     4.21   |  47.51 | 28.92 |    0.87    | [train](./scripts/causalvae/train_without_gan_loss_multi_device.sh) |
+| CausalVAE  |  8    |      1      | 25x256x256  |  FP32     |     TRUE     |  OFF |    ON |    O0  |   3 mins    |    5.45 |   36.70  | 29.28 |   0.88   |  [train](./scripts/causalvae/train_with_gan_loss_multi_device.sh) |
 
 
 ### Training Diffusion Model

--- a/examples/opensora_pku/README.md
+++ b/examples/opensora_pku/README.md
@@ -341,11 +341,11 @@ Runing this command will generate reconstructed videos under the given `output_g
 
 Here, we report the training performance and evaluation results on the UCF-101 dataset. Experiments are tested on Ascend 910* with mindspore 2.3.1 graph mode.
 
-| model name  | cards  |  graph compile | batch size | Resolution(framesxHxW) | Precision | Discriminator |data sink | jit level| Train T. (s/step) | PSNR | SSIM  |
-|:-----------|:------ |:---------------:|:----------:|:---------------------:|:----------:|:-------------:|:--------:|:-------:|-------------------:|:----:|-------:|
-| CausalVAE  |  8     |       3mins    |     1x8      |           9x256x256    |   FP32     |    TRUE      |    FALSE |     O0   |    2.04           |  29.30 |   0.88      |
-| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   BF16     |     FALSE    |    FALSE |     O0  |     4.21           | 28.92 |    0.87     |
-
+| model name  | cards  |  graph compile | batch size | Resolution(framesxHxW) | Precision | Discriminator |data sink | jit level| Train T. (s/step) | PSNR | SSIM  | num train steps|
+|:-----------|:------ |:---------------:|:----------:|:---------------------:|:----------:|:-------------:|:--------:|:-------:|-------------------:|:----:|-------:|:----:|
+| CausalVAE  |  8     |       3mins    |     1x8      |           9x256x256    |   FP32     |    TRUE      |    FALSE |     O0   |    2.04           |  29.30 |   0.88      |  40k |
+| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   BF16     |     FALSE    |    FALSE |     O0  |     4.21           | 28.92 |    0.87     |   24k |
+| CausalVAE  |  8    |       3mins     |     1x8     |           25x256x256   |   FP32     |     TRUE    |    FALSE |     O0  |      5.45     |  29.28 |   0.88   |  40k |
 
 
 ### Training Diffusion Model

--- a/examples/opensora_pku/examples/rec_video_folder.py
+++ b/examples/opensora_pku/examples/rec_video_folder.py
@@ -154,7 +154,8 @@ def main(args):
         latents = vae.encode(x)
         video_recon = vae.decode(latents)
         for idx, video in enumerate(video_recon):
-            file_name = os.path.basename(eval(str(file_paths))[idx])
+            file_paths = eval(str(file_paths).replace("/n", ","))
+            file_name = os.path.basename(file_paths[idx])
             if ".avi" in os.path.basename(file_name):
                 file_name = file_name.replace(".avi", ".mp4")
             output_path = os.path.join(generated_video_dir, file_name)

--- a/examples/opensora_pku/opensora/eval/eval_common_metrics.py
+++ b/examples/opensora_pku/opensora/eval/eval_common_metrics.py
@@ -76,6 +76,7 @@ class VideoDataset:
             self.read_from_data_file = True
         else:
             self.real_video_files = self.combine_without_prefix(real_video_dir)
+            self.read_from_data_file = False
         self.generated_video_files = self.combine_without_prefix(generated_video_dir)
         assert (
             len(self.real_video_files) == len(self.generated_video_files) and len(self.real_video_files) > 0
@@ -171,7 +172,7 @@ class VideoDataset:
                 continue
             if osp.isfile(osp.join(folder_path, name)):
                 folder.append(osp.join(folder_path, name))
-        folder = folder.sorted(folder, key=lambda x: os.path.basename(x))
+        folder = sorted(folder, key=lambda x: os.path.basename(x))
         return folder
 
 

--- a/examples/opensora_pku/opensora/eval/eval_common_metrics.py
+++ b/examples/opensora_pku/opensora/eval/eval_common_metrics.py
@@ -76,7 +76,6 @@ class VideoDataset:
             self.read_from_data_file = True
         else:
             self.real_video_files = self.combine_without_prefix(real_video_dir)
-            self.read_from_data_file = False
         self.generated_video_files = self.combine_without_prefix(generated_video_dir)
         assert (
             len(self.real_video_files) == len(self.generated_video_files) and len(self.real_video_files) > 0
@@ -172,7 +171,7 @@ class VideoDataset:
                 continue
             if osp.isfile(osp.join(folder_path, name)):
                 folder.append(osp.join(folder_path, name))
-        folder = sorted(folder, key=lambda x: os.path.basename(x))
+        folder = folder.sorted(folder, key=lambda x: os.path.basename(x))
         return folder
 
 

--- a/examples/opensora_pku/opensora/models/causalvideovae/model/losses/discriminator.py
+++ b/examples/opensora_pku/opensora/models/causalvideovae/model/losses/discriminator.py
@@ -42,7 +42,6 @@ class Conv3d(nn.Cell):
 
     def construct(self, x):
         if x.dtype == ms.float32:
-            x = ops.cast(x, self.dtype)
             return self.conv(x).to(ms.float32)
         else:
             return self.conv(x)

--- a/examples/opensora_pku/opensora/models/causalvideovae/model/losses/net_with_loss.py
+++ b/examples/opensora_pku/opensora/models/causalvideovae/model/losses/net_with_loss.py
@@ -74,8 +74,6 @@ class GeneratorWithLoss(nn.Cell):
         return kl_loss
 
     def loss_function(self, x, recons, mean, logvar, global_step: ms.Tensor = -1, weights: ms.Tensor = None, cond=None):
-        bs = x.shape[0]
-
         # For videos, treat them as independent frame images
         # TODO: regularize on temporal consistency
         t = x.shape[2]
@@ -94,15 +92,15 @@ class GeneratorWithLoss(nn.Cell):
         nll_loss = rec_loss / ops.exp(self.logvar) + self.logvar
         if weights is not None:
             weighted_nll_loss = weights * nll_loss
-            mean_weighted_nll_loss = weighted_nll_loss.sum() / bs
+            mean_weighted_nll_loss = weighted_nll_loss.sum() / weighted_nll_loss.shape[0]
             # mean_nll_loss = nll_loss.sum() / bs
         else:
-            mean_weighted_nll_loss = nll_loss.sum() / bs
+            mean_weighted_nll_loss = nll_loss.sum() / nll_loss.shape[0]
             # mean_nll_loss = mean_weighted_nll_loss
 
         # 2.3 kl loss
         kl_loss = self.kl(mean, logvar)
-        kl_loss = kl_loss.sum() / bs
+        kl_loss = kl_loss.sum() / kl_loss.shape[0]
 
         loss = mean_weighted_nll_loss + self.kl_weight * kl_loss
 

--- a/examples/opensora_pku/opensora/models/causalvideovae/model/modules/conv.py
+++ b/examples/opensora_pku/opensora/models/causalvideovae/model/modules/conv.py
@@ -155,7 +155,6 @@ class CausalConv3d(nn.Cell):
             x = ops.concat((first_frame_pad, x), axis=2)
 
         if x.dtype == ms.float32:
-            x = ops.cast(x, self.dtype)
             return self.conv(x).to(ms.float32)
         else:
             return self.conv(x)

--- a/examples/opensora_pku/opensora/train/train_causalvae.py
+++ b/examples/opensora_pku/opensora/train/train_causalvae.py
@@ -444,7 +444,15 @@ def main(args):
 
                 cur_global_step = epoch * dataset_size + step + 1  # starting from 1 for logging
                 if overflow:
-                    logger.warning(f"Overflow occurs in step {cur_global_step}")
+                    logger.warning(
+                        f"Overflow occurs in step {cur_global_step} in autoencoder"
+                        + (", drop update." if args.drop_overflow_update else ", still update.")
+                    )
+                if overflow_d:
+                    logger.warning(
+                        f"Overflow occurs in step {cur_global_step} in discriminator"
+                        + (", drop update." if args.drop_overflow_update else ", still update.")
+                    )
 
                 # log
                 step_time = time.time() - start_time_s

--- a/examples/opensora_pku/opensora/train/train_causalvae.py
+++ b/examples/opensora_pku/opensora/train/train_causalvae.py
@@ -59,7 +59,7 @@ def main(args):
     # Load Config
     assert os.path.exists(args.model_config), f"{args.model_config} does not exist!"
     model_config = json.load(open(args.model_config, "r"))
-    ae = CausalVAEModel.from_config(model_config)
+    ae = CausalVAEModel.from_config(model_config, use_recompute=args.use_recompute)
     if args.load_from_checkpoint is not None:
         ae.init_from_ckpt(args.load_from_checkpoint)
     # discriminator (D)
@@ -346,6 +346,7 @@ def main(args):
                 f"MindSpore mode[GRAPH(0)/PYNATIVE(1)]: {args.mode}",
                 f"Jit level: {args.jit_level}",
                 f"Distributed mode: {args.use_parallel}",
+                f"Recompute: {args.use_recompute}",
                 f"amp level: {amp_level}",
                 f"dtype: {args.precision}",
                 f"Use discriminator: {args.use_discriminator}",
@@ -448,7 +449,7 @@ def main(args):
                         f"Overflow occurs in step {cur_global_step} in autoencoder"
                         + (", drop update." if args.drop_overflow_update else ", still update.")
                     )
-                if overflow_d:
+                if global_step >= disc_start and overflow_d:
                     logger.warning(
                         f"Overflow occurs in step {cur_global_step} in discriminator"
                         + (", drop update." if args.drop_overflow_update else ", still update.")

--- a/examples/opensora_pku/scripts/causalvae/eval.sh
+++ b/examples/opensora_pku/scripts/causalvae/eval.sh
@@ -1,8 +1,8 @@
-python opensora/eval/eval_common_metric.py \
+python opensora/eval/eval_common_metrics.py \
     --batch_size 2 \
     --real_video_dir ..//test_eval/release/origin \
     --generated_video_dir ../test_eval/release \
-    --device cuda \
+    --device Ascend \
     --sample_fps 10 \
     --crop_size 256 \
     --resolution 256 \

--- a/examples/opensora_pku/scripts/causalvae/train_with_gan_loss.sh
+++ b/examples/opensora_pku/scripts/causalvae/train_with_gan_loss.sh
@@ -5,8 +5,8 @@ python opensora/train/train_causalvae.py \
     --max_steps 100000 \
     --save_steps 2000 \
     --output_dir results/causalvae \
-    --video_path /home_host/ddd/workspace/datasets/UCF-101 \
-    --data_file_path /home_host/ddd/workspace/datasets/ucf101_train.csv \
+    --video_path datasets/UCF-101 \
+    --data_file_path datasets/ucf101_train.csv \
     --video_num_frames 25 \
     --resolution 256 \
     --sample_rate 2 \

--- a/examples/opensora_pku/scripts/causalvae/train_with_gan_loss.sh
+++ b/examples/opensora_pku/scripts/causalvae/train_with_gan_loss.sh
@@ -1,12 +1,13 @@
 python opensora/train/train_causalvae.py \
-    --exp_name "9x256x256" \
+    --exp_name "25x256x256" \
     --train_batch_size 1 \
     --precision fp32 \
     --max_steps 100000 \
     --save_steps 2000 \
     --output_dir results/causalvae \
-    --video_path /remote-home1/dataset/data_split_tt \
-    --video_num_frames 9 \
+    --video_path /home_host/ddd/workspace/datasets/UCF-101 \
+    --data_file_path /home_host/ddd/workspace/datasets/ucf101_train.csv \
+    --video_num_frames 25 \
     --resolution 256 \
     --sample_rate 2 \
     --dataloader_num_workers 8 \
@@ -28,3 +29,4 @@ python opensora/train/train_causalvae.py \
     --loss_type l1 \
     --disc_cls causalvideovae.model.losses.LPIPSWithDiscriminator3D \
     --disc_start 2000 \
+    --use_recompute True \

--- a/examples/opensora_pku/scripts/causalvae/train_with_gan_loss_multi_device.sh
+++ b/examples/opensora_pku/scripts/causalvae/train_with_gan_loss_multi_device.sh
@@ -12,8 +12,8 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --max_steps 100000 \
     --save_steps 2000 \
     --output_dir $output_dir \
-    --video_path /home_host/ddd/workspace/datasets/UCF-101 \
-    --data_file_path /home_host/ddd/workspace/datasets/ucf101_train.csv \
+    --video_path datasets/UCF-101 \
+    --data_file_path datasets/ucf101_train.csv \
     --video_num_frames 25 \
     --resolution 256 \
     --sample_rate 2 \

--- a/examples/opensora_pku/scripts/causalvae/train_with_gan_loss_multi_device.sh
+++ b/examples/opensora_pku/scripts/causalvae/train_with_gan_loss_multi_device.sh
@@ -3,7 +3,7 @@ export MS_ENABLE_NUMA=0
 export MS_MEMORY_STATISTIC=1
 export GLOG_v=2
 output_dir="results/causalvae"
-exp_name="9x256x256"
+exp_name="25x256x256"
 
 msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --log_dir=$output_dir/$exp_name/parallel_logs opensora/train/train_causalvae.py \
     --exp_name $exp_name \
@@ -12,8 +12,9 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --max_steps 100000 \
     --save_steps 2000 \
     --output_dir $output_dir \
-    --video_path /remote-home1/dataset/data_split_tt \
-    --video_num_frames 9 \
+    --video_path /home_host/ddd/workspace/datasets/UCF-101 \
+    --data_file_path /home_host/ddd/workspace/datasets/ucf101_train.csv \
+    --video_num_frames 25 \
     --resolution 256 \
     --sample_rate 2 \
     --dataloader_num_workers 8 \
@@ -36,3 +37,4 @@ msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --
     --loss_type l1 \
     --disc_cls causalvideovae.model.losses.LPIPSWithDiscriminator3D \
     --disc_start 2000 \
+    --use_recompute True \

--- a/examples/opensora_pku/scripts/causalvae/train_without_gan_loss_multi_device.sh
+++ b/examples/opensora_pku/scripts/causalvae/train_without_gan_loss_multi_device.sh
@@ -1,0 +1,38 @@
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export MS_ENABLE_NUMA=0
+export MS_MEMORY_STATISTIC=1
+export GLOG_v=2
+output_dir="results/causalvae"
+exp_name="25x256x256"
+
+msrun --bind_core=True --worker_num=8 --local_worker_num=8 --master_port=9000 --log_dir=$output_dir/$exp_name/parallel_logs opensora/train/train_causalvae.py \
+    --exp_name $exp_name \
+    --train_batch_size 1 \
+    --precision bf16 \
+    --max_steps 100000 \
+    --save_steps 2000 \
+    --output_dir $output_dir \
+    --video_path datasets/UCF-101 \
+    --data_file_path datasets/ucf101_train.csv \
+    --video_num_frames 25 \
+    --resolution 256 \
+    --sample_rate 2 \
+    --dataloader_num_workers 8 \
+    --load_from_checkpoint pretrained/causal_vae_488_init.ckpt \
+    --start_learning_rate 1e-5 \
+    --lr_scheduler constant \
+    --optim adam \
+    --betas 0.9 0.999 \
+    --clip_grad True \
+    --weight_decay 0.0 \
+    --mode 0 \
+    --init_loss_scale 65536 \
+    --jit_level "O0" \
+    --use_discriminator False \
+    --use_parallel True \
+    --use_ema True\
+    --ema_start_step 0 \
+    --ema_decay 0.999 \
+    --perceptual_weight 1.0 \
+    --loss_type l1 \
+    --disc_cls causalvideovae.model.losses.LPIPSWithDiscriminator3D \


### PR DESCRIPTION
Support training causalvae with full precision while using recompute. 

The training step time is 5.45s. The SSIM and PSNR scores are 0.88 and 29.28. The loss is converging normally for over 40k steps.