### PR TITLE
fix unnessary flake8 E231 check whitespace

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@ max-line-length = 160
 extend-exclude =
     docs/*,
     setup.py
-extend-ignore = E203,E731
+extend-ignore = E203,E731,E231
 per-file-ignores =
     */__init__.py:F401,F403
     examples/*,tests/*:E402

--- a/examples/instantmesh/data/objaverse.py
+++ b/examples/instantmesh/data/objaverse.py
@@ -72,6 +72,7 @@ class ObjaverseDataset:
         total_view_n=32,
         fov=50,
         camera_rotation=True,
+        camera_scaling=False,
     ):
         self.root_dir = Path(root_dir)
         self.input_image_dir = input_image_dir
@@ -81,6 +82,7 @@ class ObjaverseDataset:
         self.total_view_n = total_view_n
         self.fov = fov
         self.camera_rotation = camera_rotation
+        self.camera_scaling = camera_scaling
         self.output_columns = [
             "images",
             "cameras",
@@ -280,7 +282,7 @@ class ObjaverseDataset:
             c2ws = np.matmul(rot, c2ws)
 
         # random scaling
-        if np.random.rand() < 0.5:
+        if self.camera_scaling and np.random.rand() < 0.5:
             scale = np.random.uniform(0.7, 1.1)
             c2ws[:, :3, 3] *= scale
 

--- a/examples/instantmesh/eval.py
+++ b/examples/instantmesh/eval.py
@@ -131,7 +131,7 @@ def parse_args():
     parser.add_argument(
         "--output_path",
         type=str,
-        default="output",
+        default="outputs",
         help="output dir to save the generated videos",
     )
     parser.add_argument(

--- a/examples/instantmesh/utils/eval_util.py
+++ b/examples/instantmesh/utils/eval_util.py
@@ -1,9 +1,9 @@
+import logging
 import math
 import os
 import sys
 from typing import List, Optional, Tuple, Union
 
-from loguru import logger
 from PIL import Image
 
 import mindspore as ms
@@ -13,6 +13,7 @@ from mindone.utils.seed import set_random_seed
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.abspath(os.path.join(__dir__, "../../../../..")))  # for loading mindone
+logger = logging.getLogger("")
 
 
 def str2bool(b):

--- a/examples/instantmesh/utils/loss_util.py
+++ b/examples/instantmesh/utils/loss_util.py
@@ -45,7 +45,7 @@ class LPIPS(nn.Cell):
     def load_from_pretrained(self, ckpt_path):
         if not os.path.exists(ckpt_path):
             raise ValueError(
-                f"{ckpt_path} not exists. Please download it from https: //download-mindspore.osinfra.cn/toolkits/mindone/autoencoders/lpips_vgg-426bf45c.ckpt"
+                f"{ckpt_path} not exists. Please download it from https://download-mindspore.osinfra.cn/toolkits/mindone/autoencoders/lpips_vgg-426bf45c.ckpt"
             )
 
         state_dict = ms.load_checkpoint(ckpt_path)

--- a/examples/sv3d/README.md
+++ b/examples/sv3d/README.md
@@ -15,22 +15,6 @@ ___Notice that the NeRF part for 3D optimization is not released yet. The curren
 src="https://github.com/mindspore-lab/mindone/assets/13991298/ac3d6558-e8d6-4636-9298-f2516fcbe63e"/>
 <br><em>The 3D generation pipeline leveraging the SV3D multiview diffusion model (for more information please refer to <a href="#acknowledgements">[1]</a>).</em></p>
 
-More demos can be found here. Input images are from [the Unique 3D repo](https://github.com/AiuniAI/Unique3D/tree/main/app/examples).
-<details>
-<summary>More Inference Demos
-</summary>
-
-| Input                                                                                                                | Output                     |
-|----------------------------------------------------------------------------------------------------------------------|----------------------------|
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/4f7a0c2f-65c1-4d0a-9861-068b811e0701"/><br/>aaa</p>            | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/ad492ad6-0a7a-4227-8809-b3c8ecf4db65"/><br/>aaa multiview</p> |
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/64c269c4-dfee-4495-bede-c7841b137895"/><br/>akun</p>           | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/0588fb26-aa1c-44e0-9b85-e001c6b2e67e"/><br/>akun multiview</p> |
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/9655bf80-559c-40bb-8953-c8bdea2d11a3"/><br/>anya</p>           | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/95a15c51-6fa7-4587-8e94-4f979270923f"/><br/>anya multiview</p> |
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/8bae9feb-17a1-4cbe-ae56-1f719416e3e8"/><br/>bag</p>            | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/5abff1b5-494f-4321-ae27-6125409515b8"/><br/>bag multiview</p> |
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/1b6a650a-d203-461c-a60e-fd03e9434ea8"/><br/>groot</p>          | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/413421b0-79d4-48b3-89a8-13958ff2125d"/><br/>groot multiview</p> |
-| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/5458d1db-807b-4b2e-9f0a-22415f2a0f5e"/><br/>princess-large</p> | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/6bf201a8-da31-4424-8304-42eaf6748501"/><br/>princess-large multiview</p> |
-
-</details>
-
 ## Requirements
 1. To kickstart:
 ```bash
@@ -56,6 +40,22 @@ python simple_video_sample.py \
     --ckpt PATH_TO_CKPT \
     --image PATH_TO_INPUT_IMAGE
 ```
+More demos can be found below. Input images are from [the Unique 3D repo](https://github.com/AiuniAI/Unique3D/tree/main/app/examples).
+<details>
+<summary>More Inference Demos
+</summary>
+
+| Input                                                                                                                | Output                     |
+|----------------------------------------------------------------------------------------------------------------------|----------------------------|
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/4f7a0c2f-65c1-4d0a-9861-068b811e0701"/><br/>aaa</p>            | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/ad492ad6-0a7a-4227-8809-b3c8ecf4db65"/><br/>aaa multiview</p> |
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/64c269c4-dfee-4495-bede-c7841b137895"/><br/>akun</p>           | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/0588fb26-aa1c-44e0-9b85-e001c6b2e67e"/><br/>akun multiview</p> |
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/9655bf80-559c-40bb-8953-c8bdea2d11a3"/><br/>anya</p>           | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/95a15c51-6fa7-4587-8e94-4f979270923f"/><br/>anya multiview</p> |
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/8bae9feb-17a1-4cbe-ae56-1f719416e3e8"/><br/>bag</p>            | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/5abff1b5-494f-4321-ae27-6125409515b8"/><br/>bag multiview</p> |
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/1b6a650a-d203-461c-a60e-fd03e9434ea8"/><br/>groot</p>          | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/413421b0-79d4-48b3-89a8-13958ff2125d"/><br/>groot multiview</p> |
+| <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/5458d1db-807b-4b2e-9f0a-22415f2a0f5e"/><br/>princess-large</p> | <p align="center"><img width="300" src="https://github.com/mindspore-lab/mindone/assets/13991298/6bf201a8-da31-4424-8304-42eaf6748501"/><br/>princess-large multiview</p> |
+
+</details>
+
 
 ## Training
 1. Prepare the SVD checkpoints as mentioned in the paper. SV3D needs to be finetuned from SVD to cut down training time. See [here](../svd/readme.md)

--- a/examples/sv3d/train.py
+++ b/examples/sv3d/train.py
@@ -127,9 +127,9 @@ def main(args):
             [
                 f"Debugging: {_debug}",
                 f"MindSpore mode[GRAPH(0)/PYNATIVE(1)]: {_mode}",
-                f"Num params sv3d: {num_params: , } (unet: {num_params_unet: , }, \
-                    text encoder: {num_params_text_encoder: , }, vae: {num_params_vae: , })",
-                f"Num trainable params: {num_trainable_params: , }",
+                f"Num params sv3d: {num_params:,} (unet: {num_params_unet:,}, \
+                    text encoder: {num_params_text_encoder:,}, vae: {num_params_vae:,})",
+                f"Num trainable params: {num_trainable_params:,}",
                 f"Precision sv3d: {train_cfg.amp_level}",
                 f"Num epochs: {train_cfg.epochs}",
                 f"Learning rate: {train_cfg.scheduler.lr}",

--- a/examples/sv3d/utils.py
+++ b/examples/sv3d/utils.py
@@ -21,5 +21,5 @@ def mixed_precision(net):
         ):
             setattr(net, cell, _mixed_precision(cells[cell]))
     for emb in net.conditioner.embedders:
-        if not (isinstance(emb, VideoPredictionEmbedderWithEncoder) and emb.disable_encoder_amp):
+        if not (isinstance(emb, VideoPredictionEmbedderWithEncoder) and emb.disable_encoder_autocast):
             _mixed_precision(emb)


### PR DESCRIPTION
The flake8 by default checks whether there are spaces after symbols (in [E231](https://www.flake8rules.com/rules/E231.html)), which may be wrong from time to time for the cases below.
* f-string
* `https://`

This pr fixes it, and also with some refactors for conversion tests. Without this PR, some existing code will be identified as incorrect:
* `examples/latte/sample.py`
* `examples/sv3d/train.py`