### PR TITLE
[MovieGen] Add bucketing training support and other changes

### DIFF
--- a/examples/moviegen/README.md
+++ b/examples/moviegen/README.md
@@ -65,12 +65,12 @@ this project!
 
 | MindSpore | Ascend Driver |  Firmware   | CANN toolkit/kernel |
 |:---------:|:-------------:|:-----------:|:-------------------:|
-|   2.3.1   |   24.1.RC2    | 7.3.0.1.231 |    8.0.RC2.beta1    |
+|   2.5.0   |    24.0.0     | 7.5.0.3.220 |     8.0.0.beta1     |
 
 </div>
 
 1. Install
-   [CANN 8.0.RC2.beta1](https://www.hiascend.com/developer/download/community/result?module=cann&cann=8.0.RC2.beta1)
+   [CANN 8.0.0.beta1](https://www.hiascend.com/developer/download/community/result?module=cann&cann=8.0.0.beta1)
    and MindSpore according to the [official instructions](https://www.mindspore.cn/install).
 2. Install requirements
     ```shell

--- a/examples/moviegen/README.md
+++ b/examples/moviegen/README.md
@@ -231,7 +231,7 @@ python scripts/inference_tae.py \
 --video_data.folder=/path/to/folder/with/videos/ \
 --output_path=/path/to/output/directory/ \
 --video_data.sample_n_frames=256 \
---video_data.size=[256,455]
+--video_data.size=256px
 ```
 
 > [!TIP]

--- a/examples/moviegen/README.md
+++ b/examples/moviegen/README.md
@@ -225,13 +225,17 @@ command:
 
 ```shell
 python scripts/inference_tae.py \
---tae.pretrained=/path/to/tae.ckpt \
+--tae.pretrained=models/tae_ucf101pt_mixkitft-b3b2e364.ckpt \
 --tae.dtype=bf16 \
+--tae.use_tile=True \
 --video_data.folder=/path/to/folder/with/videos/ \
 --output_path=/path/to/output/directory/ \
---video_data.size=256 \
---video_data.crop_size=[256,455]
+--video_data.sample_n_frames=256 \
+--video_data.size=[256,455]
 ```
+
+> [!TIP]
+> Set `video_data.sample_n_frames` to `-1` to encode the full videos.
 
 ### Performance
 

--- a/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
+++ b/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
@@ -9,7 +9,7 @@ model:
   name: llama-5B
   pretrained_model_path:
   enable_flash_attention: True
-  max_length: [1, 24, 24]
+  max_length: [ 1, 24, 24 ]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
+++ b/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
@@ -1,6 +1,6 @@
 env:
   mode: 0
-  jit_level: O0
+  jit_level: O1
   seed: 42
   distributed: False
   debug: False

--- a/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
+++ b/examples/moviegen/configs/inference/moviegen_t2i_256px.yaml
@@ -9,6 +9,7 @@ model:
   name: llama-5B
   pretrained_model_path:
   enable_flash_attention: True
+  max_length: [1, 24, 24]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/tae/train/mixed_256x256x16.yaml
+++ b/examples/moviegen/configs/tae/train/mixed_256x256x16.yaml
@@ -13,9 +13,8 @@ csv_path: "../videocomposer/datasets/webvid5_copy.csv"
 folder: "../videocomposer/datasets/webvid5"
 sample_stride: 1
 sample_n_frames: 16
-image_size: 256
-crop_size: 256
-# flip: True
+size: [ 256, 256 ]
+# random_flip: True
 
 # training recipe
 seed: 42

--- a/examples/moviegen/configs/tae/train/mixed_256x256x32.yaml
+++ b/examples/moviegen/configs/tae/train/mixed_256x256x32.yaml
@@ -13,9 +13,8 @@ csv_path: "../videocomposer/datasets/webvid5_copy.csv"
 folder: "../videocomposer/datasets/webvid5"
 sample_stride: 1
 sample_n_frames: 32
-image_size: 256
-crop_size: 256
-# flip: True
+size: [ 256, 256 ]
+# random_flip: True
 
 # training recipe
 seed: 42

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -61,7 +61,7 @@ train:
     min_lr: 1.0e-6
 
   optimizer:
-    name: adamw_re
+    name: adamw_bf16
     eps: 1e-15
     betas: [ 0.9, 0.999 ]
     weight_decay: 0.1

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -11,6 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
+  max_length: [1, 28, 28]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [1, 28, 28]
+  max_length: [1, 24, 24]
   dtype: bf16
 
 tae:
@@ -30,12 +30,14 @@ dataset:
     byt5: EMPTY_TEXT_EMB
   deterministic_sample: False
   text_drop_prob: 0.2
-  target_size: [ 256, 455 ]
+  target_size: 256px
   apply_transforms_dataset: True
   output_columns: [ "video", "ul2_caption", "byt5_caption" ]
 
 dataloader:
-  batch_size: 70
+  batch_size:
+    # num_frames: batch size
+    1: 25
   shuffle: True
   num_workers_dataset: 4
 
@@ -103,6 +105,8 @@ valid:
     output_columns: [ "video", "ul2_caption", "byt5_caption" ]
 
   dataloader:
-    batch_size: 50
+    batch_size:
+      # num_frames: batch size
+      1: 1
     shuffle: False
     num_workers_dataset: 4

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -1,6 +1,6 @@
 env:
   mode: 0
-  jit_level: O0
+  jit_level: O1
   seed: 42
   distributed: False
   debug: False

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -28,6 +28,7 @@ dataset:
   empty_text_emb:
     ul2: EMPTY_TEXT_EMB
     byt5: EMPTY_TEXT_EMB
+  sample_n_frames: 1
   deterministic_sample: False
   text_drop_prob: 0.2
   target_size: 256px
@@ -101,6 +102,7 @@ valid:
     text_emb_folder:
       ul2: UL2_FOLDER
       byt5: BYT5_FOLDER
+    sample_n_frames: 1
     deterministic_sample: True
     target_size: 256px
     apply_transforms_dataset: True

--- a/examples/moviegen/configs/train/stage1_t2i_256px.yaml
+++ b/examples/moviegen/configs/train/stage1_t2i_256px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [1, 24, 24]
+  max_length: [ 1, 24, 24 ]
   dtype: bf16
 
 tae:
@@ -83,7 +83,8 @@ train:
 
   save:
     ckpt_save_policy: top_k
-    monitor_metric: eval_loss_smoothed
+    monitor_metric: val_loss
+    prefer_low_perf: True  # monitor loss -> the lower, the better
     ckpt_save_interval: &save_interval 500
     ckpt_max_keep: 10
     log_interval: 1
@@ -100,7 +101,8 @@ valid:
     text_emb_folder:
       ul2: UL2_FOLDER
       byt5: BYT5_FOLDER
-    target_size: [ 256, 256 ]
+    deterministic_sample: True
+    target_size: 256px
     apply_transforms_dataset: True
     output_columns: [ "video", "ul2_caption", "byt5_caption" ]
 

--- a/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
+++ b/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [32, 28, 28]
+  max_length: [32, 24, 24]
   dtype: bf16
 
 tae:
@@ -30,15 +30,18 @@ dataset:
     byt5: EMPTY_TEXT_EMB
   deterministic_sample: False
   text_drop_prob: 0.2
-  target_size: [ 256, 455 ]
-  sample_n_frames: 256  # FIXME: add variable frames support.
+  target_size: 256px
   apply_transforms_dataset: True
   output_columns: [ "video", "ul2_caption", "byt5_caption" ]
 
 dataloader:
   batch_size:
-    image_batch_size: 1
-    video_batch_size: 1
+    # num_frames: batch size
+    1: 1
+    64: 1
+    128: 1
+    192: 1
+    256: 1
   shuffle: True
   num_workers_dataset: 4
 

--- a/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
+++ b/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
@@ -1,6 +1,6 @@
 env:
   mode: 0
-  jit_level: O0
+  jit_level: O1
   seed: 42
   distributed: False
   debug: False

--- a/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
+++ b/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
@@ -11,6 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
+  max_length: [32, 28, 28]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
+++ b/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [32, 24, 24]
+  max_length: [ 32, 24, 24 ]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
+++ b/examples/moviegen/configs/train/stage2_t2iv_256px.yaml
@@ -65,7 +65,7 @@ train:
     min_lr: 1.0e-6
 
   optimizer:
-    name: adamw_re
+    name: adamw_bf16
     eps: 1e-15
     betas: [ 0.9, 0.999 ]
     weight_decay: 0.1

--- a/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
+++ b/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
@@ -11,6 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
+  max_length: [32, 64, 64]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
+++ b/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [32, 73, 73]
+  max_length: [ 32, 73, 73 ]
   dtype: bf16
 
 tae:

--- a/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
+++ b/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
@@ -1,6 +1,6 @@
 env:
   mode: 0
-  jit_level: O0
+  jit_level: O1
   seed: 42
   distributed: False
   debug: False

--- a/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
+++ b/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
@@ -11,7 +11,7 @@ model:
   enable_flash_attention: True
   recompute_every_nth_block: 1
   not_recompute_fa: False
-  max_length: [32, 64, 64]
+  max_length: [32, 73, 73]
   dtype: bf16
 
 tae:
@@ -30,15 +30,18 @@ dataset:
     byt5: EMPTY_TEXT_EMB
   deterministic_sample: False
   text_drop_prob: 0.2
-  target_size: [ 576, 1024 ]
-  sample_n_frames: 256  # FIXME: add variable frames support.
+  target_size: 768px
   apply_transforms_dataset: True
   output_columns: [ "video", "ul2_caption", "byt5_caption" ]
 
 dataloader:
   batch_size:
-    image_batch_size: 1
-    video_batch_size: 1
+    # num_frames: batch size
+    1: 1
+    64: 1
+    128: 1
+    192: 1
+    256: 1
   shuffle: True
   num_workers_dataset: 4
 

--- a/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
+++ b/examples/moviegen/configs/train/stage3_t2iv_768px.yaml
@@ -65,7 +65,7 @@ train:
     min_lr: 1.0e-6
 
   optimizer:
-    name: adamw_re
+    name: adamw_bf16
     eps: 1e-15
     betas: [ 0.9, 0.999 ]
     weight_decay: 0.1

--- a/examples/moviegen/mg/acceleration/communications.py
+++ b/examples/moviegen/mg/acceleration/communications.py
@@ -5,7 +5,7 @@ import mindspore.ops as ops
 from mindspore import Tensor
 from mindspore.communication import GlobalComm, get_group_size, get_rank
 
-__all__ = ["SplitFowardGatherBackward", "GatherFowardSplitBackward"]
+__all__ = ["SplitForwardGatherBackward", "GatherForwardSplitBackward"]
 
 
 def _split(x: Tensor, dim: int, rank: int, world_size: int) -> Tensor:
@@ -22,7 +22,7 @@ def _communicate_along_dim(x: Tensor, dim: int, func: Callable[[Tensor], Tensor]
     return x
 
 
-class SplitFowardGatherBackward(nn.Cell):
+class SplitForwardGatherBackward(nn.Cell):
     def __init__(
         self, dim: int = 0, grad_scale: Literal["up", "down"] = "down", group: str = GlobalComm.WORLD_COMM_GROUP
     ) -> None:
@@ -46,7 +46,7 @@ class SplitFowardGatherBackward(nn.Cell):
         return (dout,)
 
 
-class GatherFowardSplitBackward(nn.Cell):
+class GatherForwardSplitBackward(nn.Cell):
     def __init__(
         self, dim: int = 0, grad_scale: Literal["up", "down"] = "up", group: str = GlobalComm.WORLD_COMM_GROUP
     ) -> None:

--- a/examples/moviegen/mg/dataset/buckets.py
+++ b/examples/moviegen/mg/dataset/buckets.py
@@ -22,7 +22,8 @@ def _get_resolutions() -> Dict[str, Dict[float, Tuple[int, int]]]:
             wr, hr = [int(a) for a in ar.split(":")]
             x = sqrt(pix_val / wr / hr)
             w, h = int(x * wr), int(x * hr)
-            w, h = w - (w % 2), h - (h % 2)  # make sides even
+            # adjust dimensions to be divisible by 16 (8x TAE downsampling and 2x patch size)
+            w, h = w - (w % 16), h - (h % 16)
             res[name][ar_val] = (h, w)
     return res
 

--- a/examples/moviegen/mg/dataset/buckets.py
+++ b/examples/moviegen/mg/dataset/buckets.py
@@ -1,13 +1,54 @@
-from typing import Callable, List, Tuple
+from math import sqrt
+from typing import Callable, Dict, List, Tuple
 
 import numpy as np
 
+__all__ = ["get_target_size", "bucket_split_function"]
 
-def bucket_split_function(
-    image_batch_size: int, video_batch_size: int
-) -> Tuple[Callable[[np.ndarray], int], List[int], List[int]]:
-    return (
-        lambda x: int(x.shape[0] > 1),  # image or video
-        [1],  # 2 buckets for now: image and videos of fixed length
-        [image_batch_size, video_batch_size],
-    )
+AR = {"1:1", "5:4", "4:3", "16:9", "16:10", "21:9", "2:1"}
+RESOLUTIONS = {"256px": 256**2, "768px": 768**2}
+
+# for internal use
+_AR = {ar: int(ar.split(":")[0]) / int(ar.split(":")[1]) for ar in AR}  # horizontal
+_AR.update({":".join(ar.split(":")[::-1]): int(ar.split(":")[1]) / int(ar.split(":")[0]) for ar in AR})  # vertical
+_ARS = np.array(list(_AR.values()))  # convert to a numpy array once
+
+
+def _get_resolutions() -> Dict[str, Dict[float, Tuple[int, int]]]:
+    res = {}
+    for name, pix_val in RESOLUTIONS.items():
+        res[name] = {}
+        for ar, ar_val in _AR.items():
+            wr, hr = [int(a) for a in ar.split(":")]
+            x = sqrt(pix_val / wr / hr)
+            w, h = int(x * wr), int(x * hr)
+            w, h = w - (w % 2), h - (h % 2)  # make sides even
+            res[name][ar_val] = (h, w)
+    return res
+
+
+_RES = _get_resolutions()
+
+
+def get_target_size(res: str, h: int, w: int) -> Tuple[int, int]:
+    ar = _ARS[np.argmin(np.abs(_ARS - w / h))]  # find the closest matching AR
+    return _RES[res][ar]  # noqa
+
+
+def bucket_split_function(frames: Dict[int, int]) -> Tuple[Callable[[np.ndarray], int], List[int], List[int]]:
+    hashed_buckets, batch_sizes, cnt = {}, [], 0
+
+    for f, bs in frames.items():
+        hashed_buckets[f] = {}
+        for ar in _AR.values():
+            hashed_buckets[f][ar] = cnt
+            batch_sizes.append(bs)
+            cnt += 1
+
+    def _bucket_split_function(video: np.ndarray) -> int:
+        # video: (T C H W)
+        t, _, h, w = video.shape
+        ar = _ARS[np.argmin(np.abs(_ARS - w / h))]  # find the closest matching AR
+        return hashed_buckets[t][ar]
+
+    return _bucket_split_function, list(range(1, cnt)), batch_sizes

--- a/examples/moviegen/mg/dataset/dataset.py
+++ b/examples/moviegen/mg/dataset/dataset.py
@@ -223,7 +223,7 @@ class ImageVideoDataset(BaseDataset):
             data["frames_mask"] = self._fmask_gen(self._t_compress_func(num_frames))
 
         if self._transforms:
-            data = self._apply_transforms(data)
+            data = self._apply_transforms(data, self._transforms)
 
         return tuple(data[c] for c in self.output_columns)
 
@@ -246,16 +246,6 @@ class ImageVideoDataset(BaseDataset):
 
     def __len__(self):
         return len(self._data)
-
-    def _apply_transforms(self, data: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
-        for transform in self._transforms:
-            input_data = tuple(data[column] for column in transform["input_columns"])
-            for op in transform["operations"]:
-                input_data = op(*input_data)
-                if not isinstance(input_data, tuple):  # wrap numpy array in a tuple
-                    input_data = (input_data,)
-            data.update(zip(transform.get("output_columns", transform["input_columns"]), input_data))
-        return data
 
     def train_transforms(
         self,

--- a/examples/moviegen/mg/dataset/transforms.py
+++ b/examples/moviegen/mg/dataset/transforms.py
@@ -1,3 +1,4 @@
+import random
 from typing import Optional, Tuple
 
 import cv2
@@ -25,6 +26,14 @@ class ResizeCrop:
         self._po = preserve_orientation
 
     def __call__(self, x: np.ndarray, size: Optional[Tuple[int, int]] = None) -> np.ndarray:
+        """
+        Args:
+            x: An array containing either an image (h, w, c) or a video (f, h, w, c).
+            size: The target size. If None, the target size must be passed during initialization.
+
+        Returns:
+            A resized and cropped image or video.
+        """
         h, w = x.shape[-3:-1]  # support images and videos
         th, tw = size or self._size
 
@@ -43,4 +52,27 @@ class ResizeCrop:
             i, j = round((x.shape[-3] - th) / 2.0), round((x.shape[-2] - tw) / 2.0)
             x = x[..., i : i + th, j : j + tw, :]
 
+        return x
+
+
+class HorizontalFlip:
+    """
+    Horizontal flip the input image or video.
+
+    Args:
+        p: The probability of horizontal flip.
+    """
+
+    def __init__(self, p: float = 0.5):
+        self._p = p
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        """
+        Args:
+            x: An array containing either an image (h, w, c) or a video (f, h, w, c).
+        Returns:
+            An image or video flipped with probability p.
+        """
+        if random.random() < self._p:
+            x = np.flip(x, axis=-2)
         return x

--- a/examples/moviegen/mg/dataset/transforms.py
+++ b/examples/moviegen/mg/dataset/transforms.py
@@ -1,5 +1,5 @@
 import random
-from typing import Optional, Tuple
+from typing import Callable, Tuple, Union
 
 import cv2
 import numpy as np
@@ -17,7 +17,7 @@ class ResizeCrop:
 
     def __init__(
         self,
-        size: Optional[Tuple[int, int]] = None,
+        size: Union[Tuple[int, int], Callable[[Tuple[int, int]], Tuple[int, int]]],
         interpolation: int = cv2.INTER_LINEAR,
         preserve_orientation: bool = True,
     ):
@@ -25,17 +25,16 @@ class ResizeCrop:
         self._inter = interpolation
         self._po = preserve_orientation
 
-    def __call__(self, x: np.ndarray, size: Optional[Tuple[int, int]] = None) -> np.ndarray:
+    def __call__(self, x: np.ndarray) -> np.ndarray:
         """
         Args:
             x: An array containing either an image (h, w, c) or a video (f, h, w, c).
-            size: The target size. If None, the target size must be passed during initialization.
 
         Returns:
             A resized and cropped image or video.
         """
         h, w = x.shape[-3:-1]  # support images and videos
-        th, tw = size or self._size
+        th, tw = self._size if isinstance(self._size, tuple) else self._size(h, w)
 
         scale = max(th / h, tw / w)
         if self._po and (new_scale := max(th / w, tw / h)) < scale:  # preserve orientation

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -11,7 +11,7 @@ from mindspore import lazy_inline, load_checkpoint, mint, nn, ops
 
 from mindone.models.utils import normal_, zeros_
 
-from ...acceleration import GatherFowardSplitBackward, SplitFowardGatherBackward, get_sequence_parallel_group
+from ...acceleration import GatherForwardSplitBackward, SplitForwardGatherBackward, get_sequence_parallel_group
 from ..text_encoders import TextProjector
 from .activation import ACT2FN
 from .block import (
@@ -235,8 +235,8 @@ class LlamaModel(nn.Cell):
         # init sequence parallel
         if (sp_group := get_sequence_parallel_group()) is not None:
             _logger.info(f"Initialize Llama model with sequence parallel group `{sp_group}`.")
-            self.split_forward_gather_backward = SplitFowardGatherBackward(dim=1, grad_scale="down", group=sp_group)
-            self.gather_forward_split_backward = GatherFowardSplitBackward(dim=1, grad_scale="up", group=sp_group)
+            self.split_forward_gather_backward = SplitForwardGatherBackward(dim=1, grad_scale="down", group=sp_group)
+            self.gather_forward_split_backward = GatherForwardSplitBackward(dim=1, grad_scale="up", group=sp_group)
         else:
             self.split_forward_gather_backward = nn.Identity()
             self.gather_forward_split_backward = nn.Identity()

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -39,7 +39,7 @@ def t2i_modulate(x: Tensor, shift: Tensor, scale: Tensor) -> Tensor:
 
 
 class LlamaDecoderLayer(nn.Cell):
-    @lazy_inline(policy="front")
+    @lazy_inline()
     def __init__(
         self,
         hidden_size: int = 4096,

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -350,6 +350,7 @@ class LlamaModel(nn.Cell):
 
         # sequence parallel start
         latent_embedding = self.split_forward_gather_backward(latent_embedding)
+        text_embedding = self.split_forward_gather_backward(text_embedding)
         position_embedding = self.split_forward_gather_backward(position_embedding)
 
         # main blocks

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -168,7 +168,7 @@ class LlamaModel(nn.Cell):
         hidden_act: str = "silu",
         initializer_range: float = 0.02,
         patch_size: Tuple[int, int, int] = (1, 2, 2),
-        max_length: Tuple[int, int, int] = (128, 64, 64),
+        max_length: Tuple[int, int, int] = (32, 73, 73),
         attn_implementation: Literal["eager", "flash_attention"] = "eager",
         recompute_every_nth_block: Optional[int] = None,
         not_recompute_fa: bool = False,

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -74,6 +74,7 @@ class LlamaDecoderLayer(nn.Cell):
             attention_dropout=attention_dropout,
             attention_bias=attention_bias,
             dtype=dtype,
+            **kwargs,
         )
 
         self.mlp = LlamaMLP(

--- a/examples/moviegen/mg/models/llama/network.py
+++ b/examples/moviegen/mg/models/llama/network.py
@@ -138,8 +138,8 @@ class LlamaFinalLayer(nn.Cell):
     ) -> None:
         super().__init__()
         self.input_layernorm = LlamaRMSNorm(hidden_size, eps=rms_norm_eps)
-        self.proj = mint.nn.Linear(
-            hidden_size, patch_size[0] * patch_size[1] * patch_size[2] * out_channels, bias=False, dtype=dtype
+        self.proj = nn.Dense(
+            hidden_size, patch_size[0] * patch_size[1] * patch_size[2] * out_channels, has_bias=False, dtype=dtype
         )
         self.scale_shift_table = Parameter(Tensor(np.random.randn(2, hidden_size) / hidden_size**0.5, dtype=dtype))
 
@@ -225,7 +225,7 @@ class LlamaModel(nn.Cell):
 
         self.timestep_embedder = TimestepEmbedder(self.hidden_size, dtype=dtype)
         self.adaLN_modulation = nn.SequentialCell(
-            ACT2FN[hidden_act], mint.nn.Linear(self.hidden_size, 6 * self.hidden_size, bias=False, dtype=dtype)
+            ACT2FN[hidden_act], nn.Dense(self.hidden_size, 6 * self.hidden_size, has_bias=False, dtype=dtype)
         )
 
         self.text_projector = TextProjector(
@@ -260,7 +260,7 @@ class LlamaModel(nn.Cell):
         std = self.initializer_range
 
         def _init_weights(module):
-            if isinstance(module, mint.nn.Linear):
+            if isinstance(module, nn.Dense):
                 normal_(module.weight, mean=0.0, std=std)
                 if module.bias is not None:
                     zeros_(module.weight)

--- a/examples/moviegen/mg/models/text_encoders/text_projector.py
+++ b/examples/moviegen/mg/models/text_encoders/text_projector.py
@@ -3,8 +3,6 @@ from typing import Type
 import mindspore as ms
 from mindspore import Tensor, mint, nn
 
-from mindone.models.utils import normal_, zeros_
-
 
 class TextProjector(nn.Cell):
     def __init__(
@@ -15,8 +13,6 @@ class TextProjector(nn.Cell):
         out_features: int = 6144,
         layer_norm: Type[nn.Cell] = mint.nn.LayerNorm,
         norm_eps: float = 1e-5,
-        initializer_range: float = 0.02,
-        post_init_weight: bool = True,
         dtype: ms.Type = ms.float32,
     ):
         super().__init__()
@@ -29,24 +25,6 @@ class TextProjector(nn.Cell):
 
         self.byt5_linear = nn.Dense(byt5_in_features, out_features, has_bias=False, dtype=dtype)
         self.byt5_layernorm = layer_norm((out_features,), eps=norm_eps, dtype=dtype)
-
-        self.initializer_range = initializer_range
-
-        # post-init
-        if post_init_weight:
-            self.initializer_range = initializer_range
-            self.init_weights()
-
-    def init_weights(self):
-        std = self.initializer_range
-
-        def _init_weights(module):
-            if isinstance(module, nn.Dense):
-                normal_(module.weight, mean=0.0, std=std)
-                if module.bias is not None:
-                    zeros_(module.weight)
-
-        self.apply(_init_weights)
 
     def construct(self, ul2_emb: Tensor, metaclip_emb: Tensor, byt5_emb: Tensor) -> Tensor:
         ul2_hidden_states = self.ul2_layernorm(self.ul2_linear(ul2_emb))

--- a/examples/moviegen/mg/models/text_encoders/text_projector.py
+++ b/examples/moviegen/mg/models/text_encoders/text_projector.py
@@ -22,13 +22,13 @@ class TextProjector(nn.Cell):
         super().__init__()
         # split layers for easier exclusion from weight decay
         self.ul2_linear = nn.Dense(ul2_in_features, out_features, has_bias=False, dtype=dtype)
-        self.ul2_layernorm = layer_norm((out_features,), eps=norm_eps)
+        self.ul2_layernorm = layer_norm((out_features,), eps=norm_eps, dtype=dtype)
 
         self.metaclip_linear = nn.Dense(metaclip_in_features, out_features, has_bias=False, dtype=dtype)
-        self.metaclip_layernorm = layer_norm((out_features,), eps=norm_eps)
+        self.metaclip_layernorm = layer_norm((out_features,), eps=norm_eps, dtype=dtype)
 
         self.byt5_linear = nn.Dense(byt5_in_features, out_features, has_bias=False, dtype=dtype)
-        self.byt5_layernorm = layer_norm((out_features,), eps=norm_eps)
+        self.byt5_layernorm = layer_norm((out_features,), eps=norm_eps, dtype=dtype)
 
         self.initializer_range = initializer_range
 

--- a/examples/moviegen/mg/models/text_encoders/text_projector.py
+++ b/examples/moviegen/mg/models/text_encoders/text_projector.py
@@ -21,13 +21,13 @@ class TextProjector(nn.Cell):
     ):
         super().__init__()
         # split layers for easier exclusion from weight decay
-        self.ul2_linear = mint.nn.Linear(ul2_in_features, out_features, bias=False, dtype=dtype)
+        self.ul2_linear = nn.Dense(ul2_in_features, out_features, has_bias=False, dtype=dtype)
         self.ul2_layernorm = layer_norm((out_features,), eps=norm_eps)
 
-        self.metaclip_linear = mint.nn.Linear(metaclip_in_features, out_features, bias=False, dtype=dtype)
+        self.metaclip_linear = nn.Dense(metaclip_in_features, out_features, has_bias=False, dtype=dtype)
         self.metaclip_layernorm = layer_norm((out_features,), eps=norm_eps)
 
-        self.byt5_linear = mint.nn.Linear(byt5_in_features, out_features, bias=False, dtype=dtype)
+        self.byt5_linear = nn.Dense(byt5_in_features, out_features, has_bias=False, dtype=dtype)
         self.byt5_layernorm = layer_norm((out_features,), eps=norm_eps)
 
         self.initializer_range = initializer_range
@@ -41,7 +41,7 @@ class TextProjector(nn.Cell):
         std = self.initializer_range
 
         def _init_weights(module):
-            if isinstance(module, mint.nn.Linear):
+            if isinstance(module, nn.Dense):
                 normal_(module.weight, mean=0.0, std=std)
                 if module.bias is not None:
                     zeros_(module.weight)

--- a/examples/moviegen/mg/pipelines/train_pipeline.py
+++ b/examples/moviegen/mg/pipelines/train_pipeline.py
@@ -48,9 +48,11 @@ class DiffusionWithLoss(nn.Cell):
         return text_emb
 
     def get_latents(self, video_tokens: Tensor) -> Tensor:
-        if self.video_emb_cached:  # (B, T, C, H, W)
+        # video_tokens: (B T C H W)
+        if self.video_emb_cached:
             return video_tokens
-        with no_grad():  # (B, C, T, H, W)
+        with no_grad():
+            video_tokens = mint.permute(video_tokens, (0, 2, 1, 3, 4))  # (B C T H W) shape is expected.
             video_emb = ops.stop_gradient(self.tae.encode(video_tokens)[0]).to(ms.float32)
             video_emb = (video_emb - self.tae.shift_factor) * self.tae.scale_factor
             video_emb = mint.permute(video_emb, (0, 2, 1, 3, 4))  # FIXME: move inside `Encoder`

--- a/examples/moviegen/mg/pipelines/train_pipeline.py
+++ b/examples/moviegen/mg/pipelines/train_pipeline.py
@@ -67,5 +67,5 @@ class DiffusionWithLoss(nn.Cell):
         ul2_emb = self.get_condition_embeddings(ul2_tokens)
         byt5_emb = self.get_condition_embeddings(byt5_tokens)
         # FIXME: add metaclip
-        metaclip_emb = mint.ones((byt5_emb.shape[0], 300, 1280), dtype=byt5_emb.dtype)
+        metaclip_emb = mint.ones((byt5_emb.shape[0], 256, 1280), dtype=byt5_emb.dtype)
         return self.network(latent_embedding, ul2_emb, metaclip_emb, byt5_emb)

--- a/examples/moviegen/mg/schedulers/rectified_flow.py
+++ b/examples/moviegen/mg/schedulers/rectified_flow.py
@@ -61,14 +61,14 @@ class RFLOW:
             timesteps = np.concatenate([linear, quadratic])
 
         timesteps = np.tile(timesteps[..., None], (1, x.shape[0]))
-        timesteps = Tensor(timesteps, dtype=model.dtype)  # FIXME: avoid calculations on tensors outside `construct`
+        timesteps = Tensor(timesteps, dtype=mstype.float32)  # FIXME: avoid calculations on tensors outside `construct`
 
         for i, timestep in tqdm(enumerate(timesteps), total=self.num_sampling_steps):
             pred = model(x, timestep, ul2_emb, metaclip_emb, byt5_emb)
 
             # update z
             dt = timesteps[i] - timesteps[i + 1] if i < len(timesteps) - 1 else timesteps[i]
-            dt = dt / self.num_timesteps
+            dt = (dt / self.num_timesteps).to(model.dtype)
             x = x + pred * dt[:, None, None, None, None]
 
         return x

--- a/examples/moviegen/mg/utils/model_utils.py
+++ b/examples/moviegen/mg/utils/model_utils.py
@@ -89,7 +89,7 @@ def init_model(
     enable_flash_attention: bool = True,
     recompute_every_nth_block: Optional[int] = None,
     not_recompute_fa: bool = False,
-    max_length: Tuple[int, int, int] = (128, 64, 64),
+    max_length: Tuple[int, int, int] = (32, 73, 73),
     dtype: Literal["fp32", "fp16", "bf16"] = "fp32",
 ) -> LlamaModel:
     attn_implementation = "flash_attention" if enable_flash_attention else "eager"

--- a/examples/moviegen/requirements.txt
+++ b/examples/moviegen/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 imageio
 av
 transformers
+plotly[express]

--- a/examples/moviegen/requirements.txt
+++ b/examples/moviegen/requirements.txt
@@ -1,1 +1,8 @@
-jsonargparse[signatures,omegaconf,urls]>=4.33.0
+jsonargparse[signatures,omegaconf,urls]~=4.35.0
+opencv-contrib-python-headless
+mindcv
+pandas
+matplotlib
+imageio
+av
+transformers

--- a/examples/moviegen/scripts/eval_tae.py
+++ b/examples/moviegen/scripts/eval_tae.py
@@ -109,13 +109,12 @@ def main(args):
     dataset = VideoDataset(
         csv_path=args.csv_path,
         folder=args.folder,
-        size=args.image_size,
-        crop_size=args.image_size,
+        size=args.size,
         sample_n_frames=args.sample_n_frames,
         sample_stride=args.sample_stride,
         video_column=args.video_column,
         random_crop=False,
-        flip=False,
+        random_flip=False,
         output_columns=["video"],
     )
     dataset = create_dataloader(

--- a/examples/moviegen/scripts/gradio_demo.py
+++ b/examples/moviegen/scripts/gradio_demo.py
@@ -63,7 +63,7 @@ def load_embeddings(selected_prompts: List[str], args) -> Tuple[ms.Tensor, ms.Te
     byt5_emb = byt5_emb.unsqueeze(0)
 
     # Create placeholder metaclip embedding matching batch size
-    metaclip_emb = ms.Tensor(np.ones((ul2_emb.shape[0], 300, 1280)), dtype=ms.float32)
+    metaclip_emb = ms.Tensor(np.ones((ul2_emb.shape[0], 256, 1280)), dtype=ms.float32)
     return ul2_emb, metaclip_emb, byt5_emb
 
 

--- a/examples/moviegen/scripts/inference.py
+++ b/examples/moviegen/scripts/inference.py
@@ -109,7 +109,7 @@ def main(args):
     prompt_prefix = [os.path.basename(emb)[:-4] for emb in ul2_emb]
     ul2_emb = ms.Tensor([np.load(emb)["text_emb"] for emb in ul2_emb], dtype=ms.float32)
     # metaclip_emb = ms.Tensor([np.load(emb)["text_emb"] for emb in metaclip_emb], dtype=ms.float32)
-    metaclip_emb = ms.Tensor(np.ones((ul2_emb.shape[0], 300, 1280)), dtype=ms.float32)  # FIXME: replace with actual
+    metaclip_emb = ms.Tensor(np.ones((ul2_emb.shape[0], 256, 1280)), dtype=ms.float32)  # FIXME: replace with actual
     byt5_emb = ms.Tensor([np.load(emb)["text_emb"] for emb in byt5_emb], dtype=ms.float32)
     num_prompts = ul2_emb.shape[0]
 

--- a/examples/moviegen/scripts/inference_tae.py
+++ b/examples/moviegen/scripts/inference_tae.py
@@ -37,8 +37,8 @@ Path_dr = path_type("dr", docstring="path to a directory that exists and is read
 def encode(args, tae: TemporalAutoencoder, save_dir: Path, rank_id: int, device_num: int, mode: int):
     dataset = VideoDataset(
         **args.video_data.init_args,
-        sample_n_frames=10**5,  # read the full video, limitation of `albumentations` (i.e., `additional_targets`)
-        output_columns=["video", "rel_path"],
+        deterministic_sample=True,
+        output_columns=[args.video_data.init_args.video_column, "rel_path"],
     )
     dataloader = create_dataloader(
         dataset, drop_remainder=False, device_num=device_num, rank_id=rank_id, **args.dataloader
@@ -52,7 +52,6 @@ def encode(args, tae: TemporalAutoencoder, save_dir: Path, rank_id: int, device_
             f"Debug mode: {args.env.debug}",
             f"TAE dtype: {args.tae.dtype}",
             f"Image size: {args.video_data.init_args.size}",
-            f"Crop size: {args.video_data.init_args.crop_size}",
             f"Num of batches: {dataloader.get_dataset_size()}",
         ]
     )
@@ -153,7 +152,7 @@ if __name__ == "__main__":
     parser.add_subclass_arguments(
         VideoDataset,
         "video_data",
-        skip={"random_crop", "flip", "sample_n_frames", "return_image", "output_columns"},
+        skip={"random_crop", "random_flip", "deterministic_sample", "return_image", "output_columns"},
         instantiate=False,
         required=False,
     )

--- a/examples/moviegen/scripts/inference_text_enc.py
+++ b/examples/moviegen/scripts/inference_text_enc.py
@@ -124,6 +124,6 @@ if __name__ == "__main__":
     )
     parser.add_function_arguments(prepare_captions, as_group=False, skip={"rank_id", "device_num"})
     parser.add_argument("--batch_size", default=10, type=int, help="Inference batch size.")
-    parser.add_argument("--model_max_length", type=int, default=300, help="Model's embedded sequence length.")
+    parser.add_argument("--model_max_length", type=int, required=True, help="Model's embedded sequence length.")
     cfg = parser.parse_args()
     main(cfg)

--- a/examples/moviegen/scripts/inference_text_enc.py
+++ b/examples/moviegen/scripts/inference_text_enc.py
@@ -105,7 +105,7 @@ def main(args):
         tokens = inputs.input_ids
         masks = inputs.attention_mask
         output = model(ms.Tensor(inputs.input_ids, dtype=ms.int32), ms.Tensor(inputs.attention_mask, dtype=ms.uint8))[0]
-        output = to_numpy(output).astype(np.float32)
+        output = to_numpy(output)
 
         for j in range(len(output)):
             paths[i + j].parent.mkdir(parents=True, exist_ok=True)

--- a/examples/moviegen/scripts/moviegen/30B_stage2_train.sh
+++ b/examples/moviegen/scripts/moviegen/30B_stage2_train.sh
@@ -14,7 +14,6 @@ msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --
 python scripts/train.py \
   --config configs/train/stage2_t2iv_256px.yaml \
   --env.mode 0 \
-  --env.jit_level O1 \
   --env.max_device_memory 59GB \
   --env.distributed True \
   --model.name=llama-30B \

--- a/examples/moviegen/scripts/moviegen/30B_stage3_train.sh
+++ b/examples/moviegen/scripts/moviegen/30B_stage3_train.sh
@@ -14,7 +14,6 @@ msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --
 python scripts/train.py \
   --config configs/train/stage3_t2iv_768px.yaml \
   --env.mode 0 \
-  --env.jit_level O1 \
   --env.max_device_memory 59GB \
   --env.distributed True \
   --model.name=llama-30B \

--- a/examples/moviegen/scripts/moviegen/stage1_train.sh
+++ b/examples/moviegen/scripts/moviegen/stage1_train.sh
@@ -11,7 +11,6 @@ msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --
 python scripts/train.py \
   --config configs/train/stage1_t2i_256px.yaml \
   --env.mode 0 \
-  --env.jit_level O1 \
   --env.max_device_memory 59GB \
   --env.distributed True \
   --train.settings.zero_stage 2 \

--- a/examples/moviegen/scripts/moviegen/stage2_train.sh
+++ b/examples/moviegen/scripts/moviegen/stage2_train.sh
@@ -14,7 +14,6 @@ msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --
 python scripts/train.py \
   --config configs/train/stage2_t2iv_256px.yaml \
   --env.mode 0 \
-  --env.jit_level O1 \
   --env.max_device_memory 59GB \
   --env.distributed True \
   --train.settings.zero_stage 2 \

--- a/examples/moviegen/scripts/moviegen/stage3_train.sh
+++ b/examples/moviegen/scripts/moviegen/stage3_train.sh
@@ -14,7 +14,6 @@ msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --
 python scripts/train.py \
   --config configs/train/stage3_t2iv_768px.yaml \
   --env.mode 0 \
-  --env.jit_level O1 \
   --env.max_device_memory 59GB \
   --env.distributed True \
   --train.settings.zero_stage 2 \

--- a/examples/moviegen/scripts/tae/decode_tae.sh
+++ b/examples/moviegen/scripts/tae/decode_tae.sh
@@ -1,0 +1,25 @@
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+LATENTS_PATH=$1
+OUT_DIR=$2
+NUM_FRAMES=$3
+
+# Set save format based on number of frames
+if [ "$NUM_FRAMES" -eq 1 ]; then
+    SAVE_FORMAT="png"
+else
+    SAVE_FORMAT="mp4"
+fi
+
+msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --log_dir="$OUT_DIR" \
+python scripts/inference_tae.py \
+--env.mode 0 \
+--env.jit_level O1 \
+--env.distributed True \
+--tae.pretrained models/tae_ucf101pt_mixkitft-b3b2e364.ckpt \
+--tae.use_tile True \
+--tae.dtype bf16 \
+--num_frames "$NUM_FRAMES" \
+--latent_data.folder "$LATENTS_PATH" \
+--output_path "$OUT_DIR" \
+--save_format "$SAVE_FORMAT"

--- a/examples/moviegen/scripts/tae/encode_tae.sh
+++ b/examples/moviegen/scripts/tae/encode_tae.sh
@@ -1,0 +1,16 @@
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+output_dir=PATH_TO_OUT_DIR
+
+msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --log_dir="$output_dir" \
+python scripts/inference_tae.py \
+--env.mode 0 \
+--env.jit_level O1 \
+--env.distributed True \
+--tae.pretrained models/tae_ucf101pt_mixkitft-b3b2e364.ckpt \
+--tae.use_tile True \
+--tae.dtype bf16 \
+--video_data.folder PATH_TO_IN_DIR \
+--video_data.sample_n_frames -1 \
+--video_data.size [192,340] \
+--output_path "$output_dir"

--- a/examples/moviegen/scripts/tae/encode_tae.sh
+++ b/examples/moviegen/scripts/tae/encode_tae.sh
@@ -12,5 +12,5 @@ python scripts/inference_tae.py \
 --tae.dtype bf16 \
 --video_data.folder PATH_TO_IN_DIR \
 --video_data.sample_n_frames -1 \
---video_data.size [192,340] \
+--video_data.size 256px \
 --output_path "$output_dir"

--- a/examples/moviegen/scripts/tae/run_eval_tae_ucf101.sh
+++ b/examples/moviegen/scripts/tae/run_eval_tae_ucf101.sh
@@ -3,7 +3,7 @@ python scripts/eval_tae.py \
 --jit_level=O1 \
 --sample_n_frames=32 \
 --batch_size 1 \
---size 256 \
+--size [256,256] \
 --pretrained outputs/train_tae/ckpt/tae-e25.ckpt \
 --csv_path datasets/ucf101_test.csv \
 --folder datasets/UCF-101 \

--- a/examples/moviegen/scripts/text_emb/generate_text_emb.sh
+++ b/examples/moviegen/scripts/text_emb/generate_text_emb.sh
@@ -1,0 +1,23 @@
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+CSV_PATH=$1
+OUT_PATH=$2
+
+mkdir -p "$OUT_PATH"/byt5_emb
+mkdir -p "$OUT_PATH"/ul2_emb
+
+msrun --bind_core=True --master_port=8200 --worker_num=8 --local_worker_num=8 --log_dir="$OUT_PATH"/byt5_emb --join=True \
+python scripts/inference_text_enc.py \
+--env.distributed True \
+--model_name google/byt5-small \
+--prompts_file "$CSV_PATH" \
+--output_path "$OUT_PATH"/byt5_emb \
+--model_max_length 128
+
+msrun --bind_core=True --master_port=8210 --worker_num=8 --local_worker_num=8 --log_dir="$OUT_PATH"/ul2_emb --join=True \
+python scripts/inference_text_enc.py \
+--env.distributed True \
+--model_name google/ul2 \
+--prompts_file "$CSV_PATH" \
+--output_path "$OUT_PATH"/ul2_emb \
+--model_max_length 512

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -188,7 +188,6 @@ def main(args):
                 ValidationCallback(
                     network=eval_diffusion_with_loss,
                     dataset=val_dataloader,
-                    alpha_smooth=0.01,  # FIXME
                     valid_frequency=args.valid.frequency,
                     ema=ema,
                 ),
@@ -220,9 +219,7 @@ def main(args):
 
     if rank_id == 0:
         callbacks.append(
-            PerfRecorderCallback(
-                args.train.output_path, file_name="result_val.log", metric_names=["eval_loss", "eval_loss_smoothed"]
-            )
+            PerfRecorderCallback(args.train.output_path, file_name="result_val.log", metric_names=["val_loss"])
         )
 
     callbacks.append(StopAtStepCallback(train_steps=args.train.steps, global_step=global_step))

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -305,7 +305,6 @@ if __name__ == "__main__":
         "train.loss_scaler",
         fail_untyped=False,  # no typing in mindspore
         help="mindspore.nn.FixedLossScaleUpdateCell or mindspore.nn.DynamicLossScaleUpdateCell",
-        instantiate=False,
     )
     parser.add_function_arguments(
         prepare_train_network, "train.settings", skip={"network", "optimizer", "scale_sense", "ema"}

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -173,8 +173,8 @@ def main(args):
         bs = Symbol(unique=True)
         video = Tensor(shape=[bs, None, args.model.in_channels if tae is None else 3, None, None], dtype=mstype.float32)
         # FIXME: fix sequence length
-        ul2_emb = Tensor(shape=[bs, 300, 4096], dtype=mstype.float32)
-        byt5_emb = Tensor(shape=[bs, 100, 1472], dtype=mstype.float32)
+        ul2_emb = Tensor(shape=[bs, 512, 4096], dtype=mstype.float32)
+        byt5_emb = Tensor(shape=[bs, 128, 1472], dtype=mstype.float32)
         net_with_grads.set_inputs(video, ul2_emb, byt5_emb)
         logger.info("Dynamic inputs are initialized for bucket config training in Graph mode.")
 

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -326,7 +326,6 @@ if __name__ == "__main__":
         skip={
             "network",
             "rank_id",
-            "shard_rank_id",
             "ckpt_save_dir",
             "output_dir",
             "ema",

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -305,6 +305,7 @@ if __name__ == "__main__":
         "train.loss_scaler",
         fail_untyped=False,  # no typing in mindspore
         help="mindspore.nn.FixedLossScaleUpdateCell or mindspore.nn.DynamicLossScaleUpdateCell",
+        instantiate=False,
     )
     parser.add_function_arguments(
         prepare_train_network, "train.settings", skip={"network", "optimizer", "scale_sense", "ema"}

--- a/examples/moviegen/tests/ut/test_transforms.py
+++ b/examples/moviegen/tests/ut/test_transforms.py
@@ -1,5 +1,6 @@
+import cv2
 import numpy as np
-from mg.dataset.transforms import ResizeCrop
+from mg.dataset.transforms import HorizontalFlip, ResizeCrop
 
 
 def test_horizontal_image_crop():
@@ -14,3 +15,29 @@ def test_vertical_image_crop():
     rc = ResizeCrop((100, 200))
     image = rc(image)
     assert image.shape == (200, 100, 3)
+
+
+def test_horizontal_video_crop():
+    video = np.random.randint(0, 256, (10, 150, 250, 3), dtype=np.uint8)
+    rc = ResizeCrop((100, 200))
+    video = rc(video)
+    assert video.shape == (10, 100, 200, 3)
+
+
+def test_vertical_video_crop():
+    video = np.random.randint(0, 256, (10, 250, 150, 3), dtype=np.uint8)
+    rc = ResizeCrop((100, 200))
+    video = rc(video)
+    assert video.shape == (10, 200, 100, 3)
+
+
+def test_horizontal_flip_image():
+    image = np.random.randint(0, 256, (128, 128, 3), dtype=np.uint8)
+    flipped_image = HorizontalFlip(p=1)(image)
+    assert (flipped_image == cv2.flip(image, 1)).all()
+
+
+def test_horizontal_flip_video():
+    video = np.random.randint(0, 256, (10, 128, 128, 3), dtype=np.uint8)
+    flipped_video = HorizontalFlip(p=1)(video)
+    assert (flipped_video == np.stack([cv2.flip(f, 1) for f in video])).all()

--- a/examples/moviegen/tools/plot.py
+++ b/examples/moviegen/tools/plot.py
@@ -1,0 +1,63 @@
+import os
+from typing import List, Optional
+
+import pandas as pd
+import plotly.express as px
+from jsonargparse import ArgumentParser
+from jsonargparse.typing import Path_fc, Path_fr
+
+
+def plot(log_files: List[Path_fr], out_path: Optional[Path_fc] = None, alpha: float = 0.01) -> None:
+    """
+    Generate an interactive plot from log files.
+    When multiple log files are provided, the plots are combined into a single figure with different prefixes.
+
+    Args:
+      log_files: List of paths to log files containing loss information.
+                 Each file should have a 'step' column and at least one data column.
+      out_path: Path where the output HTML plot will be saved.
+                If not provided, saves to 'plot.html' in the directory of the first log file.
+      alpha: Smoothing factor for exponential weighted moving average applied to the 'loss' column.
+             Values closer to 1 give more weight to recent data points. Default: 0.01.
+
+    Returns:
+      None: The function saves the plot as an HTML file and prints the save location.
+    """
+    if alpha is not None:
+        print(f"Curve smoothing enabled with {alpha=}")
+
+    dfs = []
+    for log_file in log_files:
+        df = pd.read_table(log_file)
+        df = df.rename(columns=lambda x: x.strip())  # remove padding whitespaces
+        df = df.set_index("step")  # set `step` as an index column
+        if alpha is not None:
+            df["loss"] = df["loss"].ewm(alpha=alpha).mean()
+        dfs.append(df.loc[:, ~df.columns.str.contains("time", case=False)])  # drop the `time` column
+
+    if len(dfs) > 1:  # merge multiple logs into a single dataframe by adding a unique prefix for each table
+        dfs = [df.add_prefix(f"{i}: ") for i, df in enumerate(dfs)]
+        dfs = pd.concat(dfs, axis=1)
+        title = "<br>".join([f"{i}: {os.path.dirname(log_file.relative)}" for i, log_file in enumerate(log_files)])
+    else:
+        dfs = dfs[0]
+        title = os.path.dirname(log_files[0].relative)
+
+    fig = px.line(dfs, title=title).update_traces(connectgaps=True)
+    fig.update_xaxes(gridcolor="lightgrey", fixedrange=True)  # prevent zooming on X-axis
+    fig.update_yaxes(gridcolor="lightgrey", zerolinecolor="lightgrey")
+    fig.update_layout(plot_bgcolor="white", dragmode="pan")
+
+    out_path = os.path.join(os.path.dirname(log_files[0]), "plot.html") if out_path is None else out_path.absolute
+    fig.write_html(out_path, config={"scrollZoom": True})
+    print(f"Plot saved to {out_path}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Generate an interactive plot from log files.")
+    parser.add_argument(
+        "log_files", nargs="+", type=Path_fr, help="List of paths to log files containing loss information."
+    )
+    parser.add_function_arguments(plot, skip={"log_files"}, as_group=False)
+    args = parser.parse_args()
+    plot(**args)  # noqa

--- a/mindone/trainers/callback.py
+++ b/mindone/trainers/callback.py
@@ -367,9 +367,12 @@ class EvalSaveCallback(Callback):
     def on_train_end(self, run_context):
         if self.is_main_device:
             if self.ckpt_save_policy == "top_k":
-                log_str = f"Top K checkpoints: \n{self.main_indicator}\tcheckpoint\n"
-                for p, ckpt_name in self.ckpt_manager.get_ckpt_queue():
-                    log_str += f"{p: .4f}\t{os.path.join(self.ckpt_save_dir, ckpt_name)}\n"
+                log_str = f"Top K checkpoints:\n{self.monitor_metric}\tcheckpoint\n"
+                log_str += "\n".join(
+                    f"{metric:<{len(self.monitor_metric)}.6f}\t{os.path.join(self.ckpt_save_dir, ckpt_name)}"
+                    for metric, ckpt_name in self.ckpt_manager.get_ckpt_queue()
+                )
+                _logger.info(log_str)
 
     def on_eval_end(self, run_context):
         if self.is_main_device:


### PR DESCRIPTION
**Movie Gen**:
- add bucketization support
- add full `BF16` training support (introduced in PR #869)
- add linear expansion for Positional Embedding
- switch from `mint.nn.Linear` to `nn.Dense` for better performance in dynamic graph mode
- fix `not_recompute_fa` flag in cross-attention implementation
- skip model initialization if a checkpoint is provided (decreases model instantiation time)
- add Zero SNR support following the paper

**TAE**:
- drop `albumentations` in favor of simpler transformations
- revise data loading logic for videos when the requested frame count is less than the total video length:
  - Previously: Maintained constant frame count with variable stride
  - Now: Uses fixed stride with variable frame count
- allow sampling all frames from a video when `self.sample_n_frames <= 0`
- add deterministic frame sampling

**General**:
- update benchmarks and documentation
- add a script for text embeddings generation and adjusted sequence length to match the paper
- update requirements.txt
- add interactive plot visualization

**Bugs**:
- fix SP for text embeddings (@zhtmike).
- Disable dynamic graph mode for SP as it's not supported by MS.
- Use BF16 for FA when training in full precision.