### PR TITLE
Update README for Hunyuan3D-1.0 and OpenLRM

### DIFF
--- a/examples/hunyuan3d_1/README.md
+++ b/examples/hunyuan3d_1/README.md
@@ -21,8 +21,8 @@ The framework also involves the text-to-image model, i.e., [Hunyuan-DiT](https:/
 **- Features:**
 - (optional) text-to-image
 - image background removal
-- image-to-multiviews
-- multiviews-to-mesh
+- image-to-multiviews (pynative mode)
+- multiviews-to-mesh (pynative or graph mode)
 -  (optional) mesh rendering (display device required)
 
 
@@ -35,6 +35,8 @@ Differences from original [Hunyuan3D-1.0](https://github.com/Tencent/Hunyuan3D-1
 ### Requirements
 |mindspore |	ascend driver | firmware | cann tookit/kernel|
 |--- | --- | --- | --- |
+|2.5.0 | 24.1RC2 | 7.3.0.1.231 | 8.0.RC3.beta1|
+|2.4.1 | 24.1RC2 | 7.3.0.1.231 | 8.0.RC3.beta1|
 |2.3.1 | 24.1RC2 | 7.3.0.1.231 | 8.0.RC2.beta1|
 
 ### Dependencies
@@ -101,16 +103,18 @@ We list some more useful configurations for easy usage:
 
 
 # Inference Performance
-Experiments are tested on ascend 910* with mindSpore 2.3.1 pynative mode.
 
 ## Stage 1: Image to 6 Views
+
+Experiments are tested on ascend 910* with mindSpore 2.3.1 pynative mode.
+
 | model name|precision |  cards| batch size | resolution | jit level| flash attn| scheduler| steps| s/step |img/s|  weight|
 |---|---|---|---|---|---|---|---|---|---|---|---|
 |mvd_lite|fp16| 1 | 1 | 512x512 |O0| ON | euler ancestral discrete | 50 |   1.60| 0.075 | [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/mvd_lite)|
 |mvd_std |fp16| 1 | 1 | 512x512 |O0| ON | euler ancestral discrete | 50 |   3.20| 0.038 | [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/mvd_std)|
 
 
-\*note: checkpoint weights are originally float16. Flash attention uses bfloat16.
+\*note: checkpoint weights are originally float16. Flash attention uses bfloat16. Currently only support mindspore 2.3.1 pynative mode.
 
 ### Text/Image-to-views visual results
 |Input | Lite | Std |
@@ -125,9 +129,24 @@ Experiments are tested on ascend 910* with mindSpore 2.3.1 pynative mode.
 
 ## Stage 2: Views to Mesh
 
-| model name|precision |  cards| batch size | resolution | jit level| flash attn| steps| s/step |mesh/s| recipe| weight|
-|---|---|---|---|---|---|---|---|---|---|---|---|
-|svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 32| 0.031|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+Experiments are tested on ascend 910* with pynative mode.
+
+|version | model name|precision |  cards| batch size | resolution | jit level| flash attn| steps| s/step |mesh/s| recipe| weight|
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+|mindspore 2.5.0 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 37| 0.027|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+|mindspore 2.4.1 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 33| 0.030|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+|mindspore 2.3.1 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 32| 0.031|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+
+\*note: checkpoint weights are originally float16. Flash attention always uses bfloat16, customized LayerNorm uses float32.
+
+
+Experiments are tested on ascend 910* with graph mode.
+
+|version | model name|precision |  cards| batch size | resolution | jit level| flash attn| steps| s/step |mesh/s| recipe| weight|
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+|mindspore 2.5.0 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 69| 0.014|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+|mindspore 2.4.1 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 66| 0.015|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
+|mindspore 2.3.1 |svrm |fp16| 1 | 1 | 7x512x512 |O0| ON| N/A | 63| 0.016|[svrm.yaml](./svrm/configs/svrm.yaml)| [weight](https://huggingface.co/tencent/Hunyuan3D-1/tree/main/svrm)|
 
 \*note: checkpoint weights are originally float16. Flash attention always uses bfloat16, customized LayerNorm uses float32.
 

--- a/examples/hunyuan3d_1/requirements.txt
+++ b/examples/hunyuan3d_1/requirements.txt
@@ -13,4 +13,6 @@ xatlas
 ninja
 gradio
 open3d
+PyMCubes
+typeguard
 # pyglet<2 # if do rendering locally

--- a/examples/hunyuan3d_1/svrm/ldm/modules/rendering_neus/utils/renderer.py
+++ b/examples/hunyuan3d_1/svrm/ldm/modules/rendering_neus/utils/renderer.py
@@ -20,7 +20,7 @@ ray, and computes pixel colors using the volume rendering equation.
 import mindspore as ms
 from mindspore import mint, nn, ops
 
-from ..utils import no_grad
+from ....util import no_grad
 from . import math_utils
 from .ray_marcher import MipRayMarcher2
 

--- a/examples/openlrm/README.md
+++ b/examples/openlrm/README.md
@@ -11,6 +11,7 @@ LRM is the first Large Reconstruction Model that predicts the 3D model of an obj
 ### Requirements
 |mindspore |	ascend driver | firmware | cann tookit/kernel|
 |--- | --- | --- | --- |
+|2.5.0 | 24.1RC2 | 7.3.0.1.231 | 8.0.RC3.beta1|
 |2.4.1 | 24.1RC2 | 7.3.0.1.231 | 8.0.RC3.beta1|
 
 ### Dependencies
@@ -161,8 +162,19 @@ LRM is the first Large Reconstruction Model that predicts the 3D model of an obj
 ## Performace
 
 ### Inference Performance
-Experiments are tested on ascend 910* with mindspore 2.4.1 pynative mode.
-- Input a single image, here reports speed of image-to-3D and image rendering.
+
+Input a single image, here reports speed of image-to-3D and image rendering.
+
+Experiments are tested on ascend 910* with pynative mode.
+
+- mindspore 2.5.0
+
+| model name|  cards| batch size | resolution | precision | flash attn| (image to 3D) s/step | (render) img/s|  recipe| weight|
+|---|---|---|---|---|---|---|---|---|---|
+|openlrm-obj-small-1.1 |  1 | 1 | 224x224 |fp32| OFF |  0.75  | 1.51 |[yaml](./configs/infer-s.yaml)| [weight](https://huggingface.co/zxhezexin/openlrm-obj-small-1.1)|
+|openlrm-obj-base-1.1 |  1 | 1 | 336x336 |fp32| OFF |   0.72 |  1.40 |[yaml](./configs/infer-b.yaml)| [weight](https://huggingface.co/zxhezexin/openlrm-obj-base-1.1)|
+
+- mindspore 2.4.1
 
 | model name|  cards| batch size | resolution | precision | flash attn| (image to 3D) s/step | (render) img/s|  recipe| weight|
 |---|---|---|---|---|---|---|---|---|---|
@@ -170,6 +182,8 @@ Experiments are tested on ascend 910* with mindspore 2.4.1 pynative mode.
 |openlrm-obj-small-1.1 |  1 | 1 | 224x224 |fp32| OFF |  0.72  | 2.19 |[yaml](./configs/infer-s.yaml)| [weight](https://huggingface.co/zxhezexin/openlrm-obj-small-1.1)|
 |openlrm-obj-base-1.1 |  1 | 1 | 336x336 |fp32| OFF | 0.76   | 0.98 |[yaml](./configs/infer-b.yaml)| [weight](https://huggingface.co/zxhezexin/openlrm-obj-base-1.1)|
 |openlrm-obj-large-1.1 |  1 | 1 | 448x448 |fp32| OFF | 0.92  | 0.37|[yaml](./configs/infer-l.yaml)| [weight](https://huggingface.co/zxhezexin/openlrm-obj-large-1.1)|
+
+- Visual results:
 
 |Input| Output |
 |:---|:---|
@@ -187,16 +201,18 @@ Experiments are tested on ascend 910* with mindspore 2.4.1 pynative mode.
 |---|---|---|---|---|---|---|---|
 |small | 1 | 1 | (4x)224x224 | fp32 | OFF |  2.00 | 0.50 |
 |base | 1 | 1 | (4x)336x336 | fp32 | OFF |  2.63 | 0.38 |
-|large | 1 | 1 | (4x)448x448 | bf16 | ON |  3.12 | 0.32|  
+|large | 1 | 1 | (4x)448x448 | bf16 | ON |  3.12 | 0.32|
 
 
 - Evaluation on trained models:
 
 |model name	| epoch| cards	| batch size	| resolution	| precision|  (infer+render) s/step	| PSNR | SSIM |
 |---|---|---|---|---|---|---|---|---|
-|small | 100k |1 | 1 | 224x224 | fp32  | 0.99 | 26.38 | 0.91  
-|base | 100k |1 | 1 | 336x336 | fp32  | 1.64 | 27.44 | 0.92  
-|large | 50k |1 | 1 | 448x448 | bf16  | 2.87 | 22.98 | 0.89  
+|small | 100k |1 | 1 | 224x224 | fp32  | 0.99 | 26.38 | 0.91  |
+|base | 100k |1 | 1 | 336x336 | fp32  | 1.64 | 27.44 | 0.92  |
+|large | 100k |1 | 1 | 448x448 | bf16  | 2.79 | 25.96 | 0.92 |
+
+- Intermediate results:
 
 |Input| Output (small-ep50k)| Output (base-ep40k) |
 |:---|:---|:---|


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue) 
1. Hunyuan3D-1.0, see `examples\hunyuan3d_1`
-  README added mindspore 2.4.1 and mindspore 2.5.0 multiview to 3D inference performance; currently single image to multi-views does not support either ms2.4.1 or ms.2.5.0.
- Fixed minor bugs (e.g. requirements.txt)

2. OpenLRM README added mindspore 2.5.0 performance, see `examples/openlrm`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SamitHuang 