### PR TITLE
[Refactor] Update MindSpore environment initialization function to support MS2.5

### DIFF
--- a/examples/autoencoders/train.py
+++ b/examples/autoencoders/train.py
@@ -30,7 +30,7 @@ from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
 from mindone.utils.config import instantiate_from_config
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -52,8 +52,8 @@ def create_loss_scaler(loss_scaler_type, init_loss_scale, loss_scale_factor=2, s
 
 def main(args):
     # 1. init
-    # ascend_config={"precision_mode": "allow_fp32_to_fp16"}
-    device_id, rank_id, device_num = init_train_env(
+    # precision_mode="allow_fp32_to_fp16"
+    device_id, rank_id, device_num = init_env(
         args.mode,
         device_target=args.device_target,
         seed=args.seed,

--- a/examples/dit/train.py
+++ b/examples/dit/train.py
@@ -37,7 +37,7 @@ from mindone.trainers.lr_schedule import create_scheduler
 from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -67,28 +67,15 @@ def main(args):
     args.output_path = os.path.join(args.output_path, time_str)
 
     # 1. init
-    _, rank_id, device_num = init_train_env(
+    _, rank_id, device_num = init_env(
         args.mode,
         seed=args.seed,
         distributed=args.use_parallel,
         device_target=args.device_target,
+        jit_level=args.jit_level,
         max_device_memory=args.max_device_memory,
-        ascend_config=None if args.precision_mode is None else {"precision_mode": args.precision_mode},
+        precision_mode=args.precision_mode,
     )
-    if args.mode == ms.GRAPH_MODE:
-        try:
-            if args.jit_level in ["O0", "O1", "O2"]:
-                ms.set_context(jit_config={"jit_level": args.jit_level})
-                logger.info(f"set jit_level: {args.jit_level}.")
-            else:
-                logger.warning(
-                    f"Unsupport jit_level: {args.jit_level}. The framework automatically selects the execution method"
-                )
-        except Exception:
-            logger.warning(
-                "The current jit_level is not suitable because current MindSpore version does not match,"
-                "please ensure the MindSpore version >= ms2.3_0615."
-            )
     set_logger(name="", output_dir=args.output_path, rank=rank_id, log_level=eval(args.log_level))
 
     # 2. model initiate and weight loading

--- a/examples/emu3/emu3/train/train_seq_parallel.py
+++ b/examples/emu3/emu3/train/train_seq_parallel.py
@@ -24,7 +24,7 @@ from mindone.trainers.zero import prepare_train_network
 from mindone.transformers.mindspore_adapter import MindSporeArguments
 from mindone.transformers.optimization import get_scheduler
 from mindone.transformers.training_args import TrainingArguments as tf_TrainingArguments
-from mindone.utils import count_params, init_train_env, set_logger
+from mindone.utils import count_params, init_env, set_logger
 from mindone.utils.amp import auto_mixed_precision
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ def main():
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
     # 1.0. init training env
-    device_id, rank_id, device_num = init_train_env(
+    device_id, rank_id, device_num = init_env(
         mode=training_args.mode,
         device_target=training_args.device_target,  # default: "Ascend"
         debug=training_args.debug,

--- a/examples/fit/train.py
+++ b/examples/fit/train.py
@@ -18,7 +18,6 @@ from diffusion import create_diffusion
 from pipelines.train_pipeline import NetworkWithLoss
 from utils.model_utils import load_fit_ckpt_params
 
-import mindspore as ms
 from mindspore import Model, nn
 from mindspore.nn.wrap.loss_scale import DynamicLossScaleUpdateCell
 from mindspore.train.callback import TimeMonitor
@@ -33,7 +32,7 @@ from mindone.trainers.lr_schedule import create_scheduler
 from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -63,17 +62,14 @@ def main(args):
     args.output_path = os.path.join(args.output_path, time_str)
 
     # 1. init
-    _, rank_id, device_num = init_train_env(
+    _, rank_id, device_num = init_env(
         args.mode,
         seed=args.seed,
         distributed=args.use_parallel,
         device_target=args.device_target,
+        jit_level=args.jit_level,
         max_device_memory=args.max_device_memory,
     )
-
-    if args.mode == ms.GRAPH_MODE:
-        ms.set_context(jit_config={"jit_level": args.jit_level})
-
     set_logger(name="", output_dir=args.output_path, rank=rank_id, log_level=eval(args.log_level))
 
     # 2. model initiate and weight loading

--- a/examples/hunyuanvideo/scripts/train.py
+++ b/examples/hunyuanvideo/scripts/train.py
@@ -28,7 +28,7 @@ from mindone.data import create_dataloader
 from mindone.trainers import create_optimizer, create_scheduler
 from mindone.trainers.callback import EvalSaveCallback, OverflowMonitor, StopAtStepCallback
 from mindone.trainers.zero import prepare_train_network
-from mindone.utils import count_params, init_train_env, set_logger
+from mindone.utils import count_params, init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +63,8 @@ def main(args):
     # 1. init env
     args.train.output_path = os.path.abspath(args.train.output_path)
     os.makedirs(args.train.output_path, exist_ok=True)
-    device_id, rank_id, device_num = init_train_env(**args.env)
-    mode = get_context("mode")  # `init_train_env()` may change the mode during debugging
+    device_id, rank_id, device_num = init_env(**args.env)
+    mode = get_context("mode")  # `init_env()` may change the mode during debugging
 
     # if bucketing is used in Graph mode, activate dynamic mode
     if mode == GRAPH_MODE and isinstance(args.dataloader.batch_size, dict):
@@ -328,7 +328,7 @@ if __name__ == "__main__":
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(init_model, "model", skip={"resume"})
     parser.add_function_arguments(load_vae, "vae", skip={"logger"})
     parser.add_class_arguments(

--- a/examples/hunyuanvideo/scripts/train_vae.py
+++ b/examples/hunyuanvideo/scripts/train_vae.py
@@ -29,7 +29,7 @@ from mindone.trainers import create_optimizer, create_scheduler
 from mindone.trainers.callback import EvalSaveCallback, OverflowMonitor, ProfilerCallback, StopAtStepCallback
 from mindone.trainers.checkpoint import CheckpointManager
 from mindone.trainers.zero import prepare_train_network
-from mindone.utils import count_params, init_train_env, set_logger
+from mindone.utils import count_params, init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +77,9 @@ def main(args):
     # 1. init env
     args.train.output_path = os.path.abspath(args.train.output_path)
     os.makedirs(args.train.output_path, exist_ok=True)
-    device_id, rank_id, device_num = init_train_env(**args.env)
-    mode = get_context("mode")  # `init_train_env()` may change the mode during debugging
-    # if graph mode and vae tiling is ON, uise dfs exec order
+    device_id, rank_id, device_num = init_env(**args.env)
+    mode = get_context("mode")  # `init_env()` may change the mode during debugging
+    # if graph mode and vae tiling is ON, use dfs exec order
     if mode == GRAPH_MODE and args.vae.tiling:
         set_context(exec_order="dfs")
     # 1.1 init model parallel
@@ -467,7 +467,7 @@ if __name__ == "__main__":
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(init_model, "model", skip={"resume"})
     parser.add_function_arguments(load_vae_train, "vae", skip={"logger"})
     parser.add_class_arguments(VideoDataset, "dataset", instantiate=False)

--- a/examples/instantmesh/train.py
+++ b/examples/instantmesh/train.py
@@ -31,7 +31,7 @@ from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
 from mindone.utils.config import instantiate_from_config
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 from mindone.utils.seed import set_random_seed
@@ -193,7 +193,7 @@ def main(args):
         print("make sure you are debugging now, as no ckpt will be saved.")
 
     # 1. init
-    did, rank_id, device_num = init_train_env(
+    did, rank_id, device_num = init_env(
         args.mode,
         seed=args.seed,
         distributed=args.use_parallel,

--- a/examples/latte/train.py
+++ b/examples/latte/train.py
@@ -36,7 +36,7 @@ from mindone.trainers.lr_schedule import create_scheduler
 from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -50,28 +50,15 @@ def main(args):
     args.output_path = os.path.join(args.output_path, time_str)
 
     # 1. init
-    _, rank_id, device_num = init_train_env(
+    _, rank_id, device_num = init_env(
         args.mode,
         seed=args.seed,
         distributed=args.use_parallel,
         device_target=args.device_target,
+        jit_level=args.jit_level,
         max_device_memory=args.max_device_memory,
-        ascend_config=None if args.precision_mode is None else {"precision_mode": args.precision_mode},
+        precision_mode=args.precision_mode,
     )
-    if args.ms_mode == ms.GRAPH_MODE:
-        try:
-            if args.jit_level in ["O0", "O1", "O2"]:
-                ms.set_context(jit_config={"jit_level": args.jit_level})
-                logger.info(f"set jit_level: {args.jit_level}.")
-            else:
-                logger.warning(
-                    f"Unsupport jit_level: {args.jit_level}. The framework automatically selects the execution method"
-                )
-        except Exception:
-            logger.warning(
-                "The current jit_level is not suitable because current MindSpore version does not match,"
-                "please ensure the MindSpore version >= ms2.3_0615."
-            )
     set_logger(name="", output_dir=args.output_path, rank=rank_id, log_level=eval(args.log_level))
 
     # 2. model initiate and weight loading

--- a/examples/moviegen/scripts/args_train_tae.py
+++ b/examples/moviegen/scripts/args_train_tae.py
@@ -14,7 +14,7 @@ from mg.dataset.tae_dataset import BatchTransform, VideoDataset
 from mg.models.tae import TemporalAutoencoder
 
 from mindone.data import create_dataloader
-from mindone.utils import init_train_env
+from mindone.utils import init_env
 from mindone.utils.misc import to_abspath
 
 logger = logging.getLogger()
@@ -27,9 +27,7 @@ def parse_train_args():
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(
-        init_train_env, skip={"ascend_config", "num_workers", "json_data_path", "enable_modelarts"}
-    )
+    parser.add_function_arguments(init_env)
     parser.add_class_arguments(TemporalAutoencoder, instantiate=False)
     parser.add_class_arguments(VideoDataset, skip={"output_columns"}, instantiate=False)
     parser.add_class_arguments(BatchTransform, instantiate=False)

--- a/examples/moviegen/scripts/eval_tae.py
+++ b/examples/moviegen/scripts/eval_tae.py
@@ -27,7 +27,7 @@ from mg.dataset.tae_dataset import VideoDataset
 from mg.models.tae import TemporalAutoencoder
 
 from mindone.data import create_dataloader
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 
 # from mg.models.tae.lpips import LPIPS
 
@@ -89,8 +89,7 @@ def rearrange_out(x, t):
 
 def main(args):
     # set env
-    # TODO: rename as train and infer are identical?
-    _, rank_id, device_num = init_train_env(mode=args.mode, ascend_config={"precision_mode": "must_keep_origin_dtype"})
+    _, rank_id, device_num = init_env(mode=args.mode, precision_mode="must_keep_origin_dtype")
     set_logger(name="", output_dir=args.output_path, rank=rank_id)
 
     # build model
@@ -209,9 +208,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_function_arguments(
-        init_train_env, skip={"ascend_config", "num_workers", "json_data_path", "enable_modelarts"}
-    )
+    parser.add_function_arguments(init_env)
     parser.add_class_arguments(TemporalAutoencoder, instantiate=False)
     parser.add_class_arguments(VideoDataset, skip={"output_columns"}, instantiate=False)
     parser.add_function_arguments(

--- a/examples/moviegen/scripts/gradio_demo.py
+++ b/examples/moviegen/scripts/gradio_demo.py
@@ -24,7 +24,7 @@ from mg.models.tae import TemporalAutoencoder
 from mg.pipelines import InferPipeline
 from mg.utils import init_model, to_numpy
 
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 from mindone.visualize import save_videos
 
 logger = logging.getLogger(__name__)
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     )
 
     # Add all necessary arguments
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(init_model, "model", skip={"in_channels"})
 
     # TAE parameters

--- a/examples/moviegen/scripts/inference.py
+++ b/examples/moviegen/scripts/inference.py
@@ -25,7 +25,7 @@ from mg.models.tae import TemporalAutoencoder
 from mg.pipelines import InferPipeline
 from mg.utils import init_model, to_numpy
 
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 from mindone.visualize import save_videos
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ def main(args):
         os.makedirs(latent_dir, exist_ok=True)
 
     # 1. init env
-    _, rank_id, device_num = init_train_env(**args.env)  # TODO: rename as train and infer are identical?
+    _, rank_id, device_num = init_env(**args.env)
 
     if args.enable_sequence_parallel:
         set_sequence_parallel_group(GlobalComm.WORLD_COMM_GROUP)
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(init_model, "model", skip={"resume"})
     tae_group = parser.add_argument_group("TAE parameters")
     tae_group.add_subclass_arguments(TemporalAutoencoder, "tae", instantiate=False, required=False)

--- a/examples/moviegen/scripts/inference_tae.py
+++ b/examples/moviegen/scripts/inference_tae.py
@@ -26,7 +26,7 @@ from mg.models.tae import TemporalAutoencoder
 from mg.utils import to_numpy
 
 from mindone.data import create_dataloader
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 from mindone.visualize import save_videos
 
 logger = logging.getLogger(__name__)
@@ -119,8 +119,8 @@ def decode(args, tae: TemporalAutoencoder, save_dir: Path, rank_id: int, device_
 
 def main(args):
     # 1. init env
-    _, rank_id, device_num = init_train_env(**args.env)  # TODO: rename as train and infer are identical?
-    mode = get_context("mode")  # `init_train_env()` may change the mode during debugging
+    _, rank_id, device_num = init_env(**args.env)
+    mode = get_context("mode")  # `init_env()` may change the mode during debugging
 
     save_dir = Path(args.output_path.absolute)
     save_dir.mkdir(parents=True, exist_ok=True)
@@ -148,7 +148,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="TAE inference script.")
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_class_arguments(TemporalAutoencoder, "tae", instantiate=False)
     parser.add_subclass_arguments(
         VideoDataset,

--- a/examples/moviegen/scripts/inference_text_enc.py
+++ b/examples/moviegen/scripts/inference_text_enc.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(__dir__, ".."))
 from mg.utils import MODEL_DTYPE, to_numpy
 
 from mindone.transformers.models.t5.modeling_t5 import T5EncoderModel
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ def main(args):
     os.makedirs(save_dir, exist_ok=True)
     set_logger(name="", output_dir=save_dir)
 
-    _, rank_id, device_num = init_train_env(**args.env)  # TODO: rename as train and infer are identical?
+    _, rank_id, device_num = init_env(**args.env)
 
     paths, captions = prepare_captions(args.prompts_file, args.output_path, args.column_names, rank_id, device_num)
 
@@ -117,7 +117,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Text embeddings generation script.")
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_argument("--model_name", type=str, default="google/byt5-small", help="Text encoder model name.")
     parser.add_argument(
         "--dtype", default="fp32", type=str, choices=["fp32", "fp16", "bf16"], help="Text encoder model precision."

--- a/examples/moviegen/scripts/train.py
+++ b/examples/moviegen/scripts/train.py
@@ -29,7 +29,7 @@ from mindone.data import create_dataloader
 from mindone.trainers import create_optimizer, create_scheduler
 from mindone.trainers.callback import EvalSaveCallback, OverflowMonitor, StopAtStepCallback
 from mindone.trainers.zero import prepare_train_network
-from mindone.utils import count_params, init_train_env, set_logger
+from mindone.utils import count_params, init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,8 @@ def main(args):
     # 1. init env
     args.train.output_path = os.path.abspath(args.train.output_path)
     os.makedirs(args.train.output_path, exist_ok=True)
-    device_id, rank_id, device_num = init_train_env(**args.env)
-    mode = get_context("mode")  # `init_train_env()` may change the mode during debugging
+    device_id, rank_id, device_num = init_env(**args.env)
+    mode = get_context("mode")  # `init_env()` may change the mode during debugging
 
     # if bucketing is used in Graph mode, activate dynamic mode
     if mode == GRAPH_MODE and isinstance(args.dataloader.batch_size, dict):
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(init_model, "model", skip={"resume"})
     parser.add_class_arguments(TemporalAutoencoder, "tae", instantiate=False)
     parser.add_class_arguments(

--- a/examples/moviegen/scripts/train_tae.py
+++ b/examples/moviegen/scripts/train_tae.py
@@ -29,7 +29,7 @@ from mindone.trainers.ema import EMA
 from mindone.trainers.lr_schedule import create_scheduler
 from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
-from mindone.utils import init_train_env
+from mindone.utils import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -54,7 +54,7 @@ def create_loss_scaler(loss_scaler_type, init_loss_scale, loss_scale_factor=2, s
 
 def main(args):
     # 1. init
-    _, rank_id, device_num = init_train_env(
+    _, rank_id, device_num = init_env(
         mode=args.mode,
         seed=args.seed,
         distributed=args.distributed,

--- a/examples/mvdream/MVDream-threestudio/launch.py
+++ b/examples/mvdream/MVDream-threestudio/launch.py
@@ -19,7 +19,7 @@ from mindone.trainers.checkpoint import CheckpointManager
 from mindone.trainers.recorder import PerfRecorder
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params, load_param_into_net_with_filter
 from mindone.utils.seed import set_random_seed
@@ -33,7 +33,7 @@ def launch(args, extras) -> None:
     cfg = OmegaConf.merge(cfg, cli_cfg)
     train_cfg = cfg.train_cfg
 
-    _, rank_id, device_num = init_train_env(mode=args.mode, seed=args.seed, debug=args.debug)
+    _, rank_id, device_num = init_env(mode=args.mode, seed=args.seed, debug=args.debug)
 
     if not args.debug:
         if cfg.resume is not None:

--- a/examples/openlrm/openlrm/runners/train/lrm.py
+++ b/examples/openlrm/openlrm/runners/train/lrm.py
@@ -28,7 +28,7 @@ from mindone.trainers.ema import EMA
 from mindone.trainers.lr_schedule import create_scheduler
 from mindone.trainers.optim import create_optimizer
 from mindone.trainers.train_step import TrainOneStepWrapper
-from mindone.utils import count_params, init_train_env, set_logger
+from mindone.utils import count_params, init_env, set_logger
 from mindone.utils.amp import auto_mixed_precision
 
 from .base_trainer import Trainer
@@ -51,7 +51,7 @@ class LRMTrainer(Trainer):
         print(f"Checkpoints and configs will be stored in {self.args.output_path}.")
 
         # 1. env init
-        did, self.rank_id, self.device_num = init_train_env(
+        did, self.rank_id, self.device_num = init_env(
             self.args.mode,
             seed=self.args.seed,
             distributed=self.args.use_parallel,

--- a/examples/opensora_hpcai/scripts/v2.0/inference_v2.py
+++ b/examples/opensora_hpcai/scripts/v2.0/inference_v2.py
@@ -27,7 +27,7 @@ from opensora.utils.inference import process_and_save
 from opensora.utils.sampling import SamplingOption
 from opensora.utils.saving import SavingOptions
 
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ def main(args):
     os.makedirs(save_dir, exist_ok=True)
     set_logger(name="", output_dir=save_dir)
 
-    _, rank_id, device_num = init_train_env(**args.env)  # TODO: rename as train and infer are identical?
+    _, rank_id, device_num = init_env(**args.env)
 
     # ======================================================
     # 2. build dataset and dataloader
@@ -240,7 +240,7 @@ if __name__ == "__main__":
         action=ActionConfigFile,
         help="Path to load a config yaml file that describes the setting which will override the default arguments.",
     )
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_function_arguments(prepare_captions, "text_emb", skip={"rank_id", "device_num"})
     parser.add_function_arguments(Flux, "model")
     parser.add_function_arguments(CausalVAE3D_HUNYUAN, "ae")

--- a/examples/opensora_hpcai/scripts/v2.0/text_embedding.py
+++ b/examples/opensora_hpcai/scripts/v2.0/text_embedding.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(__dir__, "../..")))
 
 from opensora.models.text_encoder import HFEmbedder
 
-from mindone.utils import init_train_env, set_logger
+from mindone.utils import init_env, set_logger
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def main(args):
     os.makedirs(save_dir, exist_ok=True)
     set_logger(name="", output_dir=save_dir)
 
-    _, rank_id, device_num = init_train_env(**args.env)  # TODO: rename as train and infer are identical?
+    _, rank_id, device_num = init_env(**args.env)
 
     paths, captions = prepare_captions(args.prompts_file, args.output_path, args.column_names, rank_id, device_num)
 
@@ -106,7 +106,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Text embeddings generation script.")
-    parser.add_function_arguments(init_train_env, "env")
+    parser.add_function_arguments(init_env, "env")
     parser.add_class_arguments(HFEmbedder, "model")
     parser.add_function_arguments(prepare_captions, as_group=False, skip={"rank_id", "device_num"})
     parser.add_argument("--batch_size", default=10, type=int, help="Inference batch size.")

--- a/examples/sv3d/train.py
+++ b/examples/sv3d/train.py
@@ -19,7 +19,7 @@ from mindone.data import create_dataloader
 from mindone.trainers import create_optimizer, create_scheduler
 from mindone.trainers.callback import EvalSaveCallback
 from mindone.trainers.train_step import TrainOneStepWrapper
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 
@@ -36,7 +36,7 @@ def main(args):
     # step 1: initialize environment
     train_cfg = OmegaConf.load(args.train_cfg)
     loss_scaler = nn.DynamicLossScaleUpdateCell(**train_cfg.LossScale)
-    device_id, rank_id, device_num = init_train_env(**train_cfg.environment)
+    device_id, rank_id, device_num = init_env(**train_cfg.environment)
     _debug = args.debug
     _mode = train_cfg.environment.mode
     if not _debug:

--- a/examples/t2i_adapter/train_t2i_adapter_sd.py
+++ b/examples/t2i_adapter/train_t2i_adapter_sd.py
@@ -10,13 +10,12 @@ from jsonargparse import ActionConfigFile, ArgumentParser
 from omegaconf import OmegaConf
 from pipelines.sd_pipeline import SDAdapterPipeline
 
-import mindspore as ms
 from mindspore import Model, nn
 from mindspore.train.callback import LossMonitor, TimeMonitor
 
 sys.path.append("../../")  # FIXME: remove in future when mindone is ready for install
 from mindone.data import create_dataloader
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 
 sys.path.append("../stable_diffusion_v2/")
 from ldm.data.transforms import TokenizerWrapper
@@ -31,9 +30,7 @@ from text_to_image import load_model_from_config
 def main(args, initializer):
     # step 1: initialize environment
     logger = logging.getLogger(__name__)
-    device_id, rank_id, device_num = init_train_env(**args.environment)
-    if args.environment.mode == ms.GRAPH_MODE:
-        ms.set_context(jit_config={"jit_level": args.jit_level})
+    device_id, rank_id, device_num = init_env(**args.environment)
     output_dir = Path(args.train.output_dir) / args.adapter.condition / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     output_dir.mkdir(parents=True, exist_ok=True)
     set_logger(output_dir=str(output_dir), rank=rank_id)
@@ -133,23 +130,13 @@ def main(args, initializer):
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--config", action=ActionConfigFile)
-    parser.add_function_arguments(init_train_env, "environment")
+    parser.add_function_arguments(init_env, "environment")
     parser.add_argument("--train.epochs", type=int, default=10, help="Number of epochs.")
     parser.add_argument(
         "--train.output_dir",
         type=str,
         default="output/t2i_adapter_v2.1/",
         help="Output directory for saving training results.",
-    )
-    parser.add_argument(
-        "--jit_level",
-        default="O0",
-        type=str,
-        choices=["O0", "O1", "O2"],
-        help="Used to control the compilation optimization level. Supports ['O0', 'O1', 'O2']."
-        "O0: Except for optimizations that may affect functionality, all other optimizations are turned off, adopt KernelByKernel execution mode."
-        "O1: Using commonly used optimizations and automatic operator fusion optimizations, adopt KernelByKernel execution mode."
-        "O2: Ultimate performance optimization, adopt Sink execution mode.",
     )
     parser.add_subclass_arguments(CondDataset, "train.dataset")
     parser.add_function_arguments(

--- a/examples/var/inference_demo.py
+++ b/examples/var/inference_demo.py
@@ -9,13 +9,13 @@ from utils.utils import load_from_checkpoint, make_grid
 import mindspore as ms
 
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.seed import set_random_seed
 
 
 def main(args):
     # init
-    init_train_env(
+    init_env(
         args.ms_mode,
         seed=args.seed,
         jit_level=args.jit_level,

--- a/examples/var/train.py
+++ b/examples/var/train.py
@@ -19,7 +19,7 @@ from mindone.trainers.ema import EMA
 from mindone.trainers.recorder import PerfRecorder
 from mindone.trainers.train_step import TrainOneStepWrapper
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.logger import set_logger
 from mindone.utils.params import count_params
 from mindone.utils.seed import set_random_seed
@@ -42,7 +42,7 @@ def create_loss_scaler(loss_scaler_type, init_loss_scale, loss_scale_factor=2, s
 
 def main(args):
     # init
-    device_id, rank_id, device_num = init_train_env(
+    device_id, rank_id, device_num = init_env(
         args.ms_mode,
         seed=args.seed,
         distributed=args.use_parallel,

--- a/examples/var/zero_shot_edit_demo.py
+++ b/examples/var/zero_shot_edit_demo.py
@@ -12,7 +12,7 @@ import mindspore as ms
 from mindspore import mint
 
 from mindone.utils.amp import auto_mixed_precision
-from mindone.utils.env import init_train_env
+from mindone.utils.env import init_env
 from mindone.utils.seed import set_random_seed
 
 
@@ -31,7 +31,7 @@ def get_edit_mask(
 
 def main(args):
     # init
-    init_train_env(
+    init_env(
         args.ms_mode,
         seed=args.seed,
         jit_level=args.jit_level,

--- a/mindone/utils/__init__.py
+++ b/mindone/utils/__init__.py
@@ -1,4 +1,4 @@
-from .env import init_train_env
+from .env import init_env
 from .logger import set_logger
 from .params import count_params
 from .weight_norm import WeightNorm

--- a/mindone/utils/env.py
+++ b/mindone/utils/env.py
@@ -1,11 +1,6 @@
 import logging
 import os
-from typing import Optional, Tuple
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # FIXME: python 3.7
+from typing import Literal, Optional, Tuple
 
 import mindspore as ms
 from mindspore.communication import get_group_size, get_rank, init
@@ -15,7 +10,7 @@ from .version_control import MS_VERSION
 _logger = logging.getLogger(__name__)
 
 
-def init_train_env(
+def init_env(
     mode: int = ms.GRAPH_MODE,
     device_target: Literal["Ascend", "GPU"] = "Ascend",
     debug: bool = False,
@@ -23,13 +18,23 @@ def init_train_env(
     cache_graph: bool = False,
     cache_path: str = "./cache",
     distributed: bool = False,
-    ascend_config: Optional[dict] = None,
+    precision_mode: Optional[
+        Literal[
+            "force_fp16",
+            "allow_fp32_to_fp16",
+            "allow_mix_precision",
+            "must_keep_origin_dtype",
+            "force_fp32",
+            "allow_fp32_to_bf16",
+            "allow_mix_precision_fp16",
+            "allow_mix_precision_bf16",
+        ]
+    ] = None,
     jit_level: Optional[Literal["O0", "O1", "O2"]] = None,
-    enable_modelarts: bool = False,
     max_device_memory: str = None,
 ) -> Tuple[int, int, int]:
     """
-    Initialize MindSpore training environment.
+    Initialize MindSpore environment.
 
     Args:
         mode: MindSpore execution mode. Options: 0 (ms.GRAPH_MODE), 1 (ms.PYNATIVE_MODE). Default is 0 (ms.GRAPH_MODE).
@@ -40,63 +45,71 @@ def init_train_env(
                      compilation time during the first epoch. Use this feature with great caution, as any changes to the
                      Python scripts may cause inconsistencies in the results.
         cache_path: The path to save or load the saved computation graph.
-        distributed: Whether to enable distributed training. Default is False.
-        ascend_config: Parameters specific to the Ascend hardware platform.
+        distributed: Whether to enable distributed execution. Default is False.
+        precision_mode: Configure mixed precision mode setting. Default is specific to hardware. For more details, please refer
+                `here <https://www.mindspore.cn/docs/en/r2.5.0/api_python/device_context/mindspore.device_context.ascend.op_precision.precision_mode.html>`__.
         jit_level: The compilation optimization level. Options: "O0", "O1", "O2".
                    Default is None and the level selected based on the device.
-        enable_modelarts: Whether to enable modelarts (OpenI) support. Default is False.
         max_device_memory (str, default: None): The maximum amount of memory that can be allocated on the Ascend device.
 
     Returns:
-        A tuple containing the device ID, rank ID and number of devices.
+        A tuple containing the device ID, rank ID, and number of devices.
     """
     ms.set_seed(seed)
+    device_id = os.getenv("DEVICE_ID", None)
+    if device_id is not None:
+        device_id = int(device_id)
 
-    if debug and mode == ms.GRAPH_MODE:  # force PyNative mode when debugging
-        _logger.warning("Debug mode is on, switching execution mode to PyNative.")
-        mode = ms.PYNATIVE_MODE
-    if max_device_memory is not None:
-        ms.set_context(max_device_memory=max_device_memory)
+    context_kwargs = {}
+    if MS_VERSION >= "2.5.0":
+        if cache_graph:
+            os.environ["MS_COMPILER_CACHE_ENABLE"] = "1"
+            os.environ["MS_COMPILER_CACHE_PATH"] = cache_path
+
+        ms.set_device(device_target, device_id=device_id)
+        if max_device_memory:
+            ms.set_memory(max_size=max_device_memory)
+        if precision_mode:
+            ms.device_context.ascend.op_precision.precision_mode(precision_mode)
+        if debug:
+            if mode == ms.GRAPH_MODE:
+                _logger.warning("Debug mode is on, switching execution mode to PyNative.")
+            context_kwargs.update(mode=ms.PYNATIVE_MODE)
+            ms.runtime.launch_blocking()
+    else:
+        context_kwargs.update(device_target=device_target)
+        if device_id is not None:
+            context_kwargs.update(device_id=device_id)
+        if max_device_memory:
+            context_kwargs.update(max_device_memory=max_device_memory)
+        if precision_mode:
+            context_kwargs.update(ascend_config={"precision_mode": precision_mode})
+        if debug:
+            if mode == ms.GRAPH_MODE:
+                _logger.warning("Debug mode is on, switching execution mode to PyNative.")
+            context_kwargs.update(mode=ms.PYNATIVE_MODE, pynative_synchronize=debug)
+        if cache_graph:
+            context_kwargs.update(enable_compile_cache=cache_graph, compile_cache_path=cache_path)
+
     if jit_level:
         if MS_VERSION >= "2.3":
-            ms.set_context(jit_config={"jit_level": jit_level})
+            context_kwargs.update(jit_config={"jit_level": jit_level})
         else:
             _logger.warning("Compilation optimization (JIT Level) is supported only in MindSpore 2.3 or later.")
 
-    if distributed:
-        ms.set_context(mode=mode, device_target=device_target, ascend_config=ascend_config or {})
-        device_id = os.getenv("DEVICE_ID", None)
-        if device_id:
-            ms.set_context(device_id=int(device_id))
+    ms.set_context(**context_kwargs)
 
+    rank_id, device_num = 0, 1
+    if distributed:
         init()
-        device_num = get_group_size()
-        rank_id = get_rank()
-        _logger.debug(f"Device_id: {device_id}, rank_id: {rank_id}, device_num: {device_num}")
+        rank_id, device_num = get_rank(), get_group_size()
+        _logger.debug(f"{device_id=}, {rank_id=}, {device_num=}")
         ms.reset_auto_parallel_context()
         ms.set_auto_parallel_context(
-            parallel_mode=ms.ParallelMode.DATA_PARALLEL,
-            gradients_mean=True,
-            device_num=device_num,
+            parallel_mode=ms.ParallelMode.DATA_PARALLEL, gradients_mean=True, device_num=device_num
         )
         var_info = ["device_num", "rank_id", "device_num / 8", "rank_id / 8"]
         var_value = [device_num, rank_id, device_num // 8, rank_id // 8]
         _logger.info(dict(zip(var_info, var_value)))
-
-        if enable_modelarts:
-            raise NotImplementedError("ModelArts is not supported yet.")
-    else:
-        device_num = 1
-        device_id = int(os.getenv("DEVICE_ID", 0))
-        rank_id = 0
-        ms.set_context(
-            mode=mode,
-            device_target=device_target,
-            device_id=device_id,
-            ascend_config=ascend_config or {},
-            pynative_synchronize=debug,
-            enable_compile_cache=cache_graph,
-            compile_cache_path=cache_path,
-        )
 
     return device_id, rank_id, device_num

--- a/mindone/utils/env.py
+++ b/mindone/utils/env.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional, Union
 
 import mindspore as ms
 from mindspore.communication import get_group_size, get_rank, init
@@ -32,7 +32,7 @@ def init_env(
     ] = None,
     jit_level: Optional[Literal["O0", "O1", "O2"]] = None,
     max_device_memory: str = None,
-) -> Tuple[int, int, int]:
+) -> tuple[Union[int, None], int, int]:
     """
     Initialize MindSpore environment.
 


### PR DESCRIPTION
This PR:
- Updates the environment initialization function to support MS2.5.
- Renames the function from `init_train_env` to `init_env`, as it is used for both training and inference.