### PR TITLE
fix(diffusers/flux-lora): fix dtype error in final inference when training with text encoder.

### DIFF
--- a/examples/diffusers/dreambooth/train_dreambooth_lora_flux.py
+++ b/examples/diffusers/dreambooth/train_dreambooth_lora_flux.py
@@ -1470,6 +1470,23 @@ def main(args):
                 epoch=epoch + 1,
             )
 
+    # Notes: repeated pipeline initalization might cause oom, so we still use the pipeline defined at the begining
+    # instead of loading a new one, and the components are updated during training.
+    # lora weigts saving might change dtypes of some layers, so we do final inference before saving, or it might raise dtype error.
+
+    # Final inference
+    if args.validation_prompt and args.num_validation_images > 0:
+        pipeline_args = {"prompt": args.validation_prompt, "num_inference_steps": 25}
+        log_validation(
+            pipeline,
+            args,
+            trackers,
+            logging_dir,
+            pipeline_args,
+            args.num_train_epochs,
+            is_final_validation=True,
+        )
+
     # Save the lora layers
     if is_master(args):
         if args.upcast_before_saving:
@@ -1487,19 +1504,6 @@ def main(args):
             save_directory=args.output_dir,
             transformer_lora_layers=transformer_lora_layers,
             text_encoder_lora_layers=text_encoder_lora_layers,
-        )
-
-    # Final inference
-    if args.validation_prompt and args.num_validation_images > 0:
-        pipeline_args = {"prompt": args.validation_prompt, "num_inference_steps": 25}
-        log_validation(
-            pipeline,
-            args,
-            trackers,
-            logging_dir,
-            pipeline_args,
-            args.num_train_epochs,
-            is_final_validation=True,
         )
 
     # End of training


### PR DESCRIPTION
before: save weights and do final inference
after: do final infernece before saving weights


During training, we upcast the text encoder to fp32 and save weights in fp32 -- this follows the orginal hf script.

Unlike hf, we don't reinitialize the pipeline and load LoRA weights for validation, as MindSpore lacks an equivalent to empty_cache() and reinitialization can cause OOM. Instead, we use a persistent pipeline throughout training, with components updated in-place.

Saving weights can change some layer dtypes (e.g., to fp32), causing dtype mismatch during final validation. To avoid this, we run final inference before saving weights.
