### PR TITLE
fix(transformers): fix some bugs

### DIFF
--- a/mindone/utils/weight_norm.py
+++ b/mindone/utils/weight_norm.py
@@ -1,16 +1,16 @@
 import mindspore as ms
-from mindspore import Parameter, nn, ops
+from mindspore import Parameter, mint, nn, ops
 
 
 def norm_except_dim(v, pow, dim):
     if dim == -1:
-        return ops.norm(v, pow)
+        return mint.norm(v, pow)
     elif dim == 0:
         output_size = (v.shape[0],) + (1,) * (v.ndim - 1)
-        return ops.norm(v.view((v.shape[0], -1)), pow, 1).view(output_size)
+        return mint.norm(v.view((v.shape[0], -1)), pow, 1).view(output_size)
     elif dim == (v.ndim - 1):
         output_size = (1,) * (v.ndim - 1) + (v.shape[v.ndim - 1],)
-        return ops.norm(v.view((-1, v.shape[v.ndim - 1])), pow, 0).view(output_size)
+        return mint.norm(v.view((-1, v.shape[v.ndim - 1])), pow, 0).view(output_size)
     else:
         return norm_except_dim(v.transpose(0, v.ndim - 1), pow, 0).transpose(0, v.ndim - 1)
 

--- a/tests/transformers_tests/integrations/test_sdpa_attention.py
+++ b/tests/transformers_tests/integrations/test_sdpa_attention.py
@@ -32,6 +32,22 @@ def q_k_v_target_mask() -> dict[str, tuple]:
     }
 
 
+@pytest.fixture(scope="module")
+def q_k_v_target_float_mask() -> dict[str, tuple]:
+    # B, H, S, D
+    set_seed(42)
+    q = np.random.uniform(size=(2, 8, 256, 32)).astype(np.float32)
+    k = np.random.uniform(size=(2, 8, 256, 32)).astype(np.float32)
+    v = np.random.uniform(size=(2, 8, 256, 32)).astype(np.float32)
+    target = np.random.uniform(size=(2, 256, 8, 32)).astype(np.float32)
+    attention_mask = np.random.randint(0, 2, (q.shape[0], 1, q.shape[2], k.shape[2]))
+    attention_mask = np.where(attention_mask == 1, float("-inf"), attention_mask).astype(np.float32)
+    return {
+        "ms": (tensor(q), tensor(k), tensor(v), tensor(target), tensor(attention_mask)),
+        "pt": (torch.tensor(q), torch.tensor(k), torch.tensor(v), torch.tensor(target), torch.tensor(attention_mask)),
+    }
+
+
 def cast_inputs(q, k, v, target, attention_mask, dtype):
     return (
         q.to(dtype),
@@ -39,6 +55,16 @@ def cast_inputs(q, k, v, target, attention_mask, dtype):
         v.to(dtype),
         target.to(dtype),
         attention_mask,  # no casting needed for attention_mask
+    )
+
+
+def cast_inputs_float_attn_mask(q, k, v, target, attention_mask, dtype):
+    return (
+        q.to(dtype),
+        k.to(dtype),
+        v.to(dtype),
+        target.to(dtype),
+        attention_mask.to(dtype),
     )
 
 
@@ -151,6 +177,214 @@ def test_sdpa_attention_causal_backward(q_k_v_target_mask, dtype: str, jit: bool
     q_pt.requires_grad, k_pt.requires_grad, v_pt.requires_grad = (True,) * 3
 
     output_pt = sdpa_attention_forward_transformers(module, q_pt, k_pt, v_pt, attention_mask=None)[0]
+    loss = torch.nn.functional.mse_loss(output_pt, target_pt)
+    loss.backward()
+    grad_out_pt = torch.stack([q_pt.grad, k_pt.grad, v_pt.grad], dim=0)
+
+    assert grad_out.shape == grad_out_pt.shape, f"Shape mismatch: {grad_out.shape} vs {grad_out_pt.shape}"
+    assert not grad_out.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        grad_out.numpy().astype(np.float32), grad_out_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_float_attn_mask_forward(q_k_v_target_float_mask, use_mask: bool, dtype: str, jit: bool):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=False)
+
+    q, k, v, _, attn_mask = cast_inputs_float_attn_mask(*q_k_v_target_float_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype])
+    q_pt, k_pt, v_pt, _, attn_mask_pt = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype]
+    )
+
+    output = sdpa_attention_forward(module, q, k, v, attention_mask=attn_mask if use_mask else None, is_causal=False)[0]
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=False
+    )[0]
+
+    assert output.shape == output_pt.shape, f"Shape mismatch: {output.shape} vs {output_pt.shape}"
+    assert not output.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        output.numpy().astype(np.float32), output_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_float_attn_mask_backward(q_k_v_target_float_mask, use_mask: bool, dtype: str, jit: bool):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=False)
+
+    # MindONE
+    q, k, v, target, attn_mask = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype]
+    )
+
+    def _forward(q_, k_, v_, target_):
+        output = sdpa_attention_forward(
+            module, q_, k_, v_, attention_mask=attn_mask if use_mask else None, is_causal=False
+        )[0]
+        return mint.nn.functional.mse_loss(output, target_)
+
+    grad_out = grad(_forward, grad_position=(0, 1, 2))(q, k, v, target)
+    grad_out = mint.stack(grad_out, dim=0)
+
+    # Transformers
+    q_pt, k_pt, v_pt, target_pt, attn_mask_pt = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype]
+    )
+    q_pt, k_pt, v_pt = q_pt.clone(), k_pt.clone(), v_pt.clone()
+    q_pt.requires_grad, k_pt.requires_grad, v_pt.requires_grad = (True,) * 3
+
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=False
+    )[0]
+    loss = torch.nn.functional.mse_loss(output_pt, target_pt)
+    loss.backward()
+    grad_out_pt = torch.stack([q_pt.grad, k_pt.grad, v_pt.grad], dim=0)
+
+    assert grad_out.shape == grad_out_pt.shape, f"Shape mismatch: {grad_out.shape} vs {grad_out_pt.shape}"
+    assert not grad_out.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        grad_out.numpy().astype(np.float32), grad_out_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_causal_with_attn_mask_forward(q_k_v_target_mask, use_mask: bool, dtype: str, jit: bool):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=True)
+
+    q, k, v, _, attn_mask = cast_inputs(*q_k_v_target_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype])
+    q_pt, k_pt, v_pt, _, attn_mask_pt = cast_inputs(*q_k_v_target_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype])
+
+    output = sdpa_attention_forward(module, q, k, v, attention_mask=attn_mask if use_mask else None, is_causal=True)[0]
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=True
+    )[0]
+
+    assert output.shape == output_pt.shape, f"Shape mismatch: {output.shape} vs {output_pt.shape}"
+    assert not output.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        output.numpy().astype(np.float32), output_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_causal_with_attn_mask_backward(q_k_v_target_mask, use_mask: bool, dtype: str, jit: bool):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=True)
+
+    # MindONE
+    q, k, v, target, attn_mask = cast_inputs(*q_k_v_target_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype])
+
+    def _forward(q_, k_, v_, target_):
+        output = sdpa_attention_forward(
+            module, q_, k_, v_, attention_mask=attn_mask if use_mask else None, is_causal=True
+        )[0]
+        return mint.nn.functional.mse_loss(output, target_)
+
+    grad_out = grad(_forward, grad_position=(0, 1, 2))(q, k, v, target)
+    grad_out = mint.stack(grad_out, dim=0)
+
+    # Transformers
+    q_pt, k_pt, v_pt, target_pt, attn_mask_pt = cast_inputs(*q_k_v_target_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype])
+    q_pt, k_pt, v_pt = q_pt.clone(), k_pt.clone(), v_pt.clone()
+    q_pt.requires_grad, k_pt.requires_grad, v_pt.requires_grad = (True,) * 3
+
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=True
+    )[0]
+    loss = torch.nn.functional.mse_loss(output_pt, target_pt)
+    loss.backward()
+    grad_out_pt = torch.stack([q_pt.grad, k_pt.grad, v_pt.grad], dim=0)
+
+    assert grad_out.shape == grad_out_pt.shape, f"Shape mismatch: {grad_out.shape} vs {grad_out_pt.shape}"
+    assert not grad_out.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        grad_out.numpy().astype(np.float32), grad_out_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_causal_with_float_attn_mask_forward(
+    q_k_v_target_float_mask, use_mask: bool, dtype: str, jit: bool
+):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=True)
+
+    q, k, v, _, attn_mask = cast_inputs_float_attn_mask(*q_k_v_target_float_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype])
+    q_pt, k_pt, v_pt, _, attn_mask_pt = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype]
+    )
+
+    output = sdpa_attention_forward(module, q, k, v, attention_mask=attn_mask if use_mask else None, is_causal=True)[0]
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=True
+    )[0]
+
+    assert output.shape == output_pt.shape, f"Shape mismatch: {output.shape} vs {output_pt.shape}"
+    assert not output.isnan().any(), "Output contains NaNs."
+    assert np.allclose(
+        output.numpy().astype(np.float32), output_pt.to(torch.float32).numpy(), atol=DTYPE_AND_THRESHOLDS[dtype]
+    )
+
+
+@pytest.mark.parametrize("dtype", ["fp32", "fp16", "bf16"])
+@pytest.mark.parametrize("use_mask", [True, False], ids=["with_mask", "without_mask"])
+@pytest.mark.parametrize("jit", [False, True], ids=["eager", "jit"])
+def test_sdpa_attention_causal_with_float_attn_mask_backward(
+    q_k_v_target_float_mask, use_mask: bool, dtype: str, jit: bool
+):
+    if jit:
+        pytest.skip("`sdpa_attention_forward` can't be compiled with jit.")
+
+    module = MockAttentionModule(is_causal=True)
+
+    # MindONE
+    q, k, v, target, attn_mask = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["ms"], dtype=MS_DTYPE_MAPPING[dtype]
+    )
+
+    def _forward(q_, k_, v_, target_):
+        output = sdpa_attention_forward(
+            module, q_, k_, v_, attention_mask=attn_mask if use_mask else None, is_causal=True
+        )[0]
+        return mint.nn.functional.mse_loss(output, target_)
+
+    grad_out = grad(_forward, grad_position=(0, 1, 2))(q, k, v, target)
+    grad_out = mint.stack(grad_out, dim=0)
+
+    # Transformers
+    q_pt, k_pt, v_pt, target_pt, attn_mask_pt = cast_inputs_float_attn_mask(
+        *q_k_v_target_float_mask["pt"], dtype=PT_DTYPE_MAPPING[dtype]
+    )
+    q_pt, k_pt, v_pt = q_pt.clone(), k_pt.clone(), v_pt.clone()
+    q_pt.requires_grad, k_pt.requires_grad, v_pt.requires_grad = (True,) * 3
+
+    output_pt = sdpa_attention_forward_transformers(
+        module, q_pt, k_pt, v_pt, attention_mask=attn_mask_pt if use_mask else None, is_causal=True
+    )[0]
     loss = torch.nn.functional.mse_loss(output_pt, target_pt)
     loss.backward()
     grad_out_pt = torch.stack([q_pt.grad, k_pt.grad, v_pt.grad], dim=0)

--- a/tests/transformers_tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
+++ b/tests/transformers_tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
@@ -15,7 +15,7 @@ import inspect
 import numpy as np
 import pytest
 import torch
-from transformers.models.xlm_roberta_xl.configuration_xlm_roberta_xl import XLMXLMRobertaConfig
+from transformers.models.xlm_roberta_xl.configuration_xlm_roberta_xl import XLMRobertaXLConfig
 
 import mindspore as ms
 
@@ -103,7 +103,7 @@ class XLMRobertaXLModelTester:
         return config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
 
     def get_config(self):
-        return XLMXLMRobertaConfig(
+        return XLMRobertaXLConfig(
             attn_implementation="eager",
             vocab_size=self.vocab_size,
             hidden_size=self.hidden_size,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

</p>
<hr>
<h1>SDPA Issues</h1>

### **Bug 1**

`mindspore.ops.speed_fusion_attention` is **not equivalent** to `torch.nn.functional.scaled_dot_product_attention`.  

Currently, PyTorch's `scaled_dot_product_attention` supports three implementations:

1. **[FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning](https://arxiv.org/abs/2307.08691)**
2. **[Memory-Efficient Attention](https://github.com/facebookresearch/xformers)**
3. A **C++ PyTorch implementation** matching the standard formulation.

> If the user requires a specific fused implementation, the C++ PyTorch implementation can be disabled via [`torch.nn.attention.sdpa_kernel()`](https://docs.pytorch.org/docs/stable/generated/torch.nn.attention.sdpa_kernel.html#torch.nn.attention.sdpa_kernel).

`ops.speed_fusion_attention` in MindSpore is used for **self-attention fusion computation**.

#### Scaled Dot Product Attention Implementation and NaN Handling

I implemented a `scaled_dot_product_attention` function **referencing `torch.nn.functional.scaled_dot_product_attention`**, with additional handling for causal masks.

##### Forward Pass

In my implementation, I explicitly check for **entire rows in the attention logits**. If a row consists entirely of `-inf` values before the softmax, the forward result would normally become `NaN`:

$$
\text{softmax}([-\infty, -\infty, \dots, -\infty]) 
= \frac{[e^{-\infty}, e^{-\infty}, \dots]}{\sum_i e^{-\infty}} 
= \frac{[0, 0, \dots]}{0} 
= \text{NaN}
$$

However, in `torch.nn.functional.scaled_dot_product_attention`, such rows are safely replaced with zeros:

$$
\text{softmax}([-\infty, -\infty, \dots, -\infty]) = [0, 0, \dots, 0]
$$

This prevents `NaN` in the **forward pass**.

##### Backward Pass

Without this handling, the backward gradients also become `NaN`. 
Mathematically, for softmax: $softmax(x)_i = e^{x_i} / \sum_j e^{x_j}$.

$$
\frac{\partial \text{softmax}(x)_i}{\partial x_k} =
\begin{cases}
\text{softmax}(x)_i (1 - \text{softmax}(x)_i), & \text{if } i = k \\
-\text{softmax}(x)_i \text{softmax}(x)_k, & \text{if } i \neq k
\end{cases}
$$


If `x = [-inf, -inf, ..., -inf]`, then:

$$
\text{softmax}(x)_i = \text{NaN}, \quad
\frac{\partial \text{softmax}(x)_i}{\partial x_k} = \text{NaN}.
$$

By replacing the entire row with zeros before and after softmax, both **forward and backward passes** are well-defined:

$$
softmax^{safe}(x)_i = 0, \quad 
\frac{\partial}{\partial x_k} softmax^{safe}(x)_i = 0
$$


<hr>
<h3><strong>Bug 2</strong></h3>
<p>When <code inline="">is_causal=True</code>, <code inline="">torch.nn.functional.scaled_dot_product_attention</code> <strong>does not</strong> simply assert <code inline="">attn_mask is None</code>.<br>
Instead:</p>
<ul>
<li>
<p>If <code inline="">attn_mask</code> is <strong>boolean</strong>, the result is the <strong>intersection</strong> of <code inline="">is_causal</code> and <code inline="">attn_mask</code>.</p>
</li>
<li>
<p>If <code inline="">attn_mask</code> is <strong>floating-point</strong>, the result is the <strong>addition</strong> of <code inline="">is_causal</code> and <code inline="">attn_mask</code>.</p>
</li>
</ul>
<p>This can be verified by the following examples:</p>

> **Note:** Boolean Mask

```python
import torch
import torch.nn.functional as F

batch_size, num_heads, seq_len, head_dim = 1, 1, 4, 8
query = torch.randn(batch_size, num_heads, seq_len, head_dim)
key = torch.randn(batch_size, num_heads, seq_len, head_dim)
value = torch.randn(batch_size, num_heads, seq_len, head_dim)

attention_mask = torch.ones(seq_len, seq_len, dtype=torch.bool)
attention_mask[2:, :] = False   # user-defined mask
causal_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool), 0)

# condition 1: is_causal=True + attention_mask
out1 = F.scaled_dot_product_attention(query, key, value,
                                      attn_mask=attention_mask,
                                      is_causal=True,
                                      dropout_p=0.0)

# condition 2: only attention_mask
out2 = F.scaled_dot_product_attention(query, key, value,
                                      attn_mask=attention_mask,
                                      is_causal=False,
                                      dropout_p=0.0)

# condition 3: only causal
out3 = F.scaled_dot_product_attention(query, key, value,
                                      attn_mask=None,
                                      is_causal=True,
                                      dropout_p=0.0)

# condition 4: attention_mask &amp; causal_mask
out4 = F.scaled_dot_product_attention(
    query, key, value,
    attn_mask= attention_mask & causal_mask,
    is_causal=False,
    dropout_p=0.0,
)

print(torch.allclose(out1, out2))  # False
print(torch.allclose(out1, out3))  # False
print(torch.allclose(out1, out4))  # True
```

> **Note:** Floating-Point Mask

```python
import torch
import torch.nn.functional as F

L = 4
query = torch.randn(1, 1, L, 8)
key   = torch.randn(1, 1, L, 8)
value = torch.randn(1, 1, L, 8)

attention_mask = torch.zeros(L, L)
attention_mask[2:, :] = float('-inf')

# causal mask
causal_mask = torch.triu(torch.full((L, L), float('-inf')), diagonal=1)

# condition 1: causal=True + attention_mask
out1 = F.scaled_dot_product_attention(query, key, value,
                                      attn_mask=attention_mask,
                                      is_causal=True)

# condition 2: causal=False + attention_mask + causal_mask
out2 = F.scaled_dot_product_attention(query, key, value,
                                      attn_mask=attention_mask + causal_mask,
                                      is_causal=False)

print(torch.allclose(out1, out2))  # True
```
<hr>
<h3><strong>Other Notes</strong></h3>
<ul>
<li>
<p><code inline="">ops.norm</code> does not support <code inline="">bf16</code>, replace it with <code inline="">mint.norm</code>.</p>
</li>
<li>
<p>Add <code inline="">sdpa</code> test cases.</p>
</li>
<li>
<p><code inline="">mint.nn.BatchNorm2d</code>:</p>
<ul>
<li>
<p>If we use <code inline="">set_dtype</code> on the <code inline="">Parameter</code>, then <code inline="">num_batches_tracked</code> (which should be <code inline="">int64</code>) will also be converted.</p>
</li>
<li>
<p>But in <code inline="">state_dict</code>, <code inline="">num_batches_tracked</code> is <code inline="">int64</code> in fact.</p>
</li>
<li>
<p>Solution: remove <code inline="">.to(ms.float32)</code> and add a proper check in <code inline="">modeling_test_utils.py</code>.</p>
</li>
</ul>
</li>
</ul>
<hr>
<p>


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
