### PR TITLE
fix(transformers): mindone.transfomers v4.50.0 fast ut bugfix

### DIFF
--- a/mindone/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
+++ b/mindone/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
@@ -85,7 +85,7 @@ class GPTNeoXJapaneseAttention(nn.Cell):
         self.dense = mint.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
         # Activate bias if the last layer
         self.use_bias = use_bias
-        self.dense_bias = nn.Parameter(mint.zeros(config.hidden_size)) if use_bias else None
+        self.dense_bias = ms.Parameter(mint.zeros(config.hidden_size)) if use_bias else None
 
     def construct(
         self,

--- a/tests/transformers_tests/models/gptj/test_modeling_gptj.py
+++ b/tests/transformers_tests/models/gptj/test_modeling_gptj.py
@@ -158,7 +158,7 @@ GPTJ_CASES = [
             "attention_mask": input_mask,
         },
         {
-            "last_hidden_state": 1,
+            "last_hidden_state": 0,
         },
     ],
 ]

--- a/tests/transformers_tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/transformers_tests/models/owlvit/test_modeling_owlvit.py
@@ -316,6 +316,7 @@ def prepare_img():
     return Image.open(requests.get(url, stream=True).raw)
 
 
+@pytest.mark.slow
 def test_inference():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -344,6 +345,7 @@ def test_inference():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_interpolate_pos_encoding():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -466,6 +468,7 @@ def test_inference_interpolate_pos_encoding():
     assert outputs.target_pred_boxes.shape == (1, num_queries, 4)
 
 
+@pytest.mark.slow
 def test_inference_object_detection():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -504,6 +507,7 @@ def test_inference_object_detection():
     assert objects_text_labels == ["a photo of a cat", "a photo of a cat"]
 
 
+@pytest.mark.slow
 def test_inference_one_shot_object_detection():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -527,6 +531,7 @@ def test_inference_one_shot_object_detection():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_one_shot_object_detection_fp16():
     model_name = "google/owlvit-base-patch32"
     model = OwlViTForObjectDetection.from_pretrained(model_name, mindspore_dtype=ms.float16)

--- a/tests/transformers_tests/models/qwen3_moe/test_modeling_qwen3_moe.py
+++ b/tests/transformers_tests/models/qwen3_moe/test_modeling_qwen3_moe.py
@@ -22,7 +22,7 @@ import inspect
 import numpy as np
 import pytest
 import torch
-from transformers import Qwen3MoeConfig
+import transformers
 
 import mindspore as ms
 
@@ -38,238 +38,238 @@ from tests.transformers_tests.models.modeling_common import ids_numpy
 DTYPE_AND_THRESHOLDS = {"fp32": 5e-4, "fp16": 5e-3, "bf16": 5e-2}
 MODES = [1]
 
+if transformers.__version__ >= "4.51.0":
+    from transformers import Qwen3MoeConfig
 
-class Qwen3MoeModelTester:
-    def __init__(
-        self,
-        batch_size=13,
-        seq_length=7,
-        is_training=True,
-        use_input_mask=True,
-        use_token_type_ids=True,
-        use_labels=True,
-        vocab_size=99,
-        hidden_size=64,
-        num_hidden_layers=5,
-        max_window_layers=3,
-        use_sliding_window=True,
-        sliding_window=50,
-        num_attention_heads=4,
-        num_key_value_heads=2,
-        head_dim=16,
-        intermediate_size=37,
-        hidden_act="gelu",
-        hidden_dropout_prob=0.1,
-        attention_probs_dropout_prob=0.1,
-        max_position_embeddings=512,
-        expert_interval=1,
-        moe_intermediate_size=12,
-        num_experts_per_tok=2,
-        num_experts=8,
-        norm_topk_prob=False,
-        output_router_logits=False,
-        router_aux_loss_coef=0.001,
-        type_vocab_size=16,
-        type_sequence_label_size=2,
-        initializer_range=0.02,
-        num_labels=3,
-        num_choices=4,
-        pad_token_id=0,
-        bos_token_id=1,
-        scope=None,
+    class Qwen3MoeModelTester:
+        def __init__(
+            self,
+            batch_size=13,
+            seq_length=7,
+            is_training=True,
+            use_input_mask=True,
+            use_token_type_ids=True,
+            use_labels=True,
+            vocab_size=99,
+            hidden_size=64,
+            num_hidden_layers=5,
+            max_window_layers=3,
+            use_sliding_window=True,
+            sliding_window=50,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            intermediate_size=37,
+            hidden_act="gelu",
+            hidden_dropout_prob=0.1,
+            attention_probs_dropout_prob=0.1,
+            max_position_embeddings=512,
+            expert_interval=1,
+            moe_intermediate_size=12,
+            num_experts_per_tok=2,
+            num_experts=8,
+            norm_topk_prob=False,
+            output_router_logits=False,
+            router_aux_loss_coef=0.001,
+            type_vocab_size=16,
+            type_sequence_label_size=2,
+            initializer_range=0.02,
+            num_labels=3,
+            num_choices=4,
+            pad_token_id=0,
+            bos_token_id=1,
+            scope=None,
+        ):
+            self.batch_size = batch_size
+            self.seq_length = seq_length
+            self.is_training = is_training
+            self.use_input_mask = use_input_mask
+            self.use_token_type_ids = use_token_type_ids
+            self.use_labels = use_labels
+            self.vocab_size = vocab_size
+            self.hidden_size = hidden_size
+            self.num_hidden_layers = num_hidden_layers
+            self.max_window_layers = max_window_layers
+            self.use_sliding_window = use_sliding_window
+            self.sliding_window = sliding_window
+            self.num_attention_heads = num_attention_heads
+            self.num_key_value_heads = num_key_value_heads
+            self.head_dim = head_dim
+            self.intermediate_size = intermediate_size
+            self.hidden_act = hidden_act
+            self.hidden_dropout_prob = hidden_dropout_prob
+            self.attention_probs_dropout_prob = attention_probs_dropout_prob
+            self.max_position_embeddings = max_position_embeddings
+            self.type_vocab_size = type_vocab_size
+            self.type_sequence_label_size = type_sequence_label_size
+            self.initializer_range = initializer_range
+            self.num_labels = num_labels
+            self.num_choices = num_choices
+            self.pad_token_id = pad_token_id
+            self.bos_token_id = bos_token_id
+            self.scope = scope
+            self.expert_interval = expert_interval
+            self.moe_intermediate_size = moe_intermediate_size
+            self.num_experts_per_tok = num_experts_per_tok
+            self.num_experts = num_experts
+            self.norm_topk_prob = norm_topk_prob
+            self.output_router_logits = output_router_logits
+            self.router_aux_loss_coef = router_aux_loss_coef
+
+        # Copied from tests.models.llama.test_modeling_llama.LlamaModelTester.prepare_config_and_inputs
+        def prepare_config_and_inputs(self):
+            input_ids = ids_numpy([self.batch_size, self.seq_length], self.vocab_size)
+
+            input_mask = None
+            if self.use_input_mask:
+                input_mask = np.tril(np.ones_like(input_ids))
+
+            token_type_ids = None
+            if self.use_token_type_ids:
+                token_type_ids = ids_numpy([self.batch_size, self.seq_length], self.type_vocab_size)
+
+            sequence_labels = None
+            token_labels = None
+            choice_labels = None
+            if self.use_labels:
+                sequence_labels = ids_numpy([self.batch_size], self.type_sequence_label_size)
+                token_labels = ids_numpy([self.batch_size, self.seq_length], self.num_labels)
+                choice_labels = ids_numpy([self.batch_size], self.num_choices)
+
+            config = self.get_config()
+
+            return config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
+
+        def get_config(self):
+            return Qwen3MoeConfig(
+                vocab_size=self.vocab_size,
+                hidden_size=self.hidden_size,
+                num_hidden_layers=self.num_hidden_layers,
+                max_window_layers=self.max_window_layers,
+                use_sliding_window=self.use_sliding_window,
+                sliding_window=self.sliding_window,
+                num_attention_heads=self.num_attention_heads,
+                num_key_value_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                intermediate_size=self.intermediate_size,
+                hidden_act=self.hidden_act,
+                hidden_dropout_prob=self.hidden_dropout_prob,
+                attention_probs_dropout_prob=self.attention_probs_dropout_prob,
+                max_position_embeddings=self.max_position_embeddings,
+                expert_interval=self.expert_interval,
+                moe_intermediate_size=self.moe_intermediate_size,
+                num_experts_per_tok=self.num_experts_per_tok,
+                num_experts=self.num_experts,
+                norm_topk_prob=self.norm_topk_prob,
+                output_router_logits=self.output_router_logits,
+                router_aux_loss_coef=self.router_aux_loss_coef,
+                type_vocab_size=self.type_vocab_size,
+                is_decoder=False,
+                initializer_range=self.initializer_range,
+                pad_token_id=self.pad_token_id,
+                bos_token_id=self.bos_token_id,
+            )
+
+        # Copied from tests.models.llama.test_modeling_llama.LlamaModelTester.prepare_config_and_inputs_for_common
+        def prepare_config_and_inputs_for_common(self):
+            config_and_inputs = self.prepare_config_and_inputs()
+            (
+                config,
+                input_ids,
+                token_type_ids,
+                input_mask,
+                sequence_labels,
+                token_labels,
+                choice_labels,
+            ) = config_and_inputs
+            return config, input_ids, input_mask
+
+    model_tester = Qwen3MoeModelTester()
+    config, input_ids, input_mask = model_tester.prepare_config_and_inputs_for_common()
+
+    QWEN3MOE_CASES = [
+        [
+            "Qwen3MoeModel",
+            "transformers.Qwen3MoeModel",
+            "mindone.transformers.Qwen3MoeModel",
+            (config,),
+            {},
+            (input_ids,),
+            {
+                "attention_mask": input_mask,
+            },
+            {
+                "last_hidden_state": 0,  # key: torch attribute, value: mindspore idx
+            },
+        ],
+    ]
+
+    @pytest.mark.parametrize(
+        "name,pt_module,ms_module,init_args,init_kwargs,inputs_args,inputs_kwargs,outputs_map,dtype,mode",
+        [
+            case
+            + [
+                dtype,
+            ]
+            + [
+                mode,
+            ]
+            for case in QWEN3MOE_CASES
+            for dtype in DTYPE_AND_THRESHOLDS.keys()
+            for mode in MODES
+        ],
+    )
+    def test_named_modules(
+        name,
+        pt_module,
+        ms_module,
+        init_args,
+        init_kwargs,
+        inputs_args,
+        inputs_kwargs,
+        outputs_map,
+        dtype,
+        mode,
     ):
-        self.batch_size = batch_size
-        self.seq_length = seq_length
-        self.is_training = is_training
-        self.use_input_mask = use_input_mask
-        self.use_token_type_ids = use_token_type_ids
-        self.use_labels = use_labels
-        self.vocab_size = vocab_size
-        self.hidden_size = hidden_size
-        self.num_hidden_layers = num_hidden_layers
-        self.max_window_layers = max_window_layers
-        self.use_sliding_window = use_sliding_window
-        self.sliding_window = sliding_window
-        self.num_attention_heads = num_attention_heads
-        self.num_key_value_heads = num_key_value_heads
-        self.head_dim = head_dim
-        self.intermediate_size = intermediate_size
-        self.hidden_act = hidden_act
-        self.hidden_dropout_prob = hidden_dropout_prob
-        self.attention_probs_dropout_prob = attention_probs_dropout_prob
-        self.max_position_embeddings = max_position_embeddings
-        self.type_vocab_size = type_vocab_size
-        self.type_sequence_label_size = type_sequence_label_size
-        self.initializer_range = initializer_range
-        self.num_labels = num_labels
-        self.num_choices = num_choices
-        self.pad_token_id = pad_token_id
-        self.bos_token_id = bos_token_id
-        self.scope = scope
-        self.expert_interval = expert_interval
-        self.moe_intermediate_size = moe_intermediate_size
-        self.num_experts_per_tok = num_experts_per_tok
-        self.num_experts = num_experts
-        self.norm_topk_prob = norm_topk_prob
-        self.output_router_logits = output_router_logits
-        self.router_aux_loss_coef = router_aux_loss_coef
+        ms.set_context(mode=mode)
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTester.prepare_config_and_inputs
-    def prepare_config_and_inputs(self):
-        input_ids = ids_numpy([self.batch_size, self.seq_length], self.vocab_size)
-
-        input_mask = None
-        if self.use_input_mask:
-            input_mask = np.tril(np.ones_like(input_ids))
-
-        token_type_ids = None
-        if self.use_token_type_ids:
-            token_type_ids = ids_numpy([self.batch_size, self.seq_length], self.type_vocab_size)
-
-        sequence_labels = None
-        token_labels = None
-        choice_labels = None
-        if self.use_labels:
-            sequence_labels = ids_numpy([self.batch_size], self.type_sequence_label_size)
-            token_labels = ids_numpy([self.batch_size, self.seq_length], self.num_labels)
-            choice_labels = ids_numpy([self.batch_size], self.num_choices)
-
-        config = self.get_config()
-
-        return config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
-
-    def get_config(self):
-        return Qwen3MoeConfig(
-            vocab_size=self.vocab_size,
-            hidden_size=self.hidden_size,
-            num_hidden_layers=self.num_hidden_layers,
-            max_window_layers=self.max_window_layers,
-            use_sliding_window=self.use_sliding_window,
-            sliding_window=self.sliding_window,
-            num_attention_heads=self.num_attention_heads,
-            num_key_value_heads=self.num_key_value_heads,
-            head_dim=self.head_dim,
-            intermediate_size=self.intermediate_size,
-            hidden_act=self.hidden_act,
-            hidden_dropout_prob=self.hidden_dropout_prob,
-            attention_probs_dropout_prob=self.attention_probs_dropout_prob,
-            max_position_embeddings=self.max_position_embeddings,
-            expert_interval=self.expert_interval,
-            moe_intermediate_size=self.moe_intermediate_size,
-            num_experts_per_tok=self.num_experts_per_tok,
-            num_experts=self.num_experts,
-            norm_topk_prob=self.norm_topk_prob,
-            output_router_logits=self.output_router_logits,
-            router_aux_loss_coef=self.router_aux_loss_coef,
-            type_vocab_size=self.type_vocab_size,
-            is_decoder=False,
-            initializer_range=self.initializer_range,
-            pad_token_id=self.pad_token_id,
-            bos_token_id=self.bos_token_id,
+        (
+            pt_model,
+            ms_model,
+            pt_dtype,
+            ms_dtype,
+        ) = get_modules(pt_module, ms_module, dtype, *init_args, **init_kwargs)
+        pt_inputs_args, pt_inputs_kwargs, ms_inputs_args, ms_inputs_kwargs = generalized_parse_args(
+            pt_dtype, ms_dtype, *inputs_args, **inputs_kwargs
         )
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTester.prepare_config_and_inputs_for_common
-    def prepare_config_and_inputs_for_common(self):
-        config_and_inputs = self.prepare_config_and_inputs()
-        (
-            config,
-            input_ids,
-            token_type_ids,
-            input_mask,
-            sequence_labels,
-            token_labels,
-            choice_labels,
-        ) = config_and_inputs
-        return config, input_ids, input_mask
+        if "hidden_dtype" in inspect.signature(pt_model.forward).parameters:
+            pt_inputs_kwargs.update({"hidden_dtype": PT_DTYPE_MAPPING[pt_dtype]})
+            ms_inputs_kwargs.update({"hidden_dtype": MS_DTYPE_MAPPING[ms_dtype]})
+        ms_inputs_kwargs["return_dict"] = False
 
+        with torch.no_grad():
+            pt_outputs = pt_model(*pt_inputs_args, **pt_inputs_kwargs)
+        ms_outputs = ms_model(*ms_inputs_args, **ms_inputs_kwargs)
 
-model_tester = Qwen3MoeModelTester()
-config, input_ids, input_mask = model_tester.prepare_config_and_inputs_for_common()
+        if outputs_map:
+            pt_outputs_n = []
+            ms_outputs_n = []
+            for pt_key, ms_idx in outputs_map.items():
+                pt_output = getattr(pt_outputs, pt_key)
+                ms_output = ms_outputs[ms_idx]
+                if isinstance(pt_output, (list, tuple)):
+                    pt_outputs_n += list(pt_output)
+                    ms_outputs_n += list(ms_output)
+                else:
+                    pt_outputs_n.append(pt_output)
+                    ms_outputs_n.append(ms_output)
+            diffs = compute_diffs(pt_outputs_n, ms_outputs_n)
+        else:
+            diffs = compute_diffs(pt_outputs, ms_outputs)
 
-QWEN3MOE_CASES = [
-    [
-        "Qwen3MoeModel",
-        "transformers.Qwen3MoeModel",
-        "mindone.transformers.Qwen3MoeModel",
-        (config,),
-        {},
-        (input_ids,),
-        {
-            "attention_mask": input_mask,
-        },
-        {
-            "last_hidden_state": 0,  # key: torch attribute, value: mindspore idx
-        },
-    ],
-]
-
-
-@pytest.mark.parametrize(
-    "name,pt_module,ms_module,init_args,init_kwargs,inputs_args,inputs_kwargs,outputs_map,dtype,mode",
-    [
-        case
-        + [
-            dtype,
-        ]
-        + [
-            mode,
-        ]
-        for case in QWEN3MOE_CASES
-        for dtype in DTYPE_AND_THRESHOLDS.keys()
-        for mode in MODES
-    ],
-)
-def test_named_modules(
-    name,
-    pt_module,
-    ms_module,
-    init_args,
-    init_kwargs,
-    inputs_args,
-    inputs_kwargs,
-    outputs_map,
-    dtype,
-    mode,
-):
-    ms.set_context(mode=mode)
-
-    (
-        pt_model,
-        ms_model,
-        pt_dtype,
-        ms_dtype,
-    ) = get_modules(pt_module, ms_module, dtype, *init_args, **init_kwargs)
-    pt_inputs_args, pt_inputs_kwargs, ms_inputs_args, ms_inputs_kwargs = generalized_parse_args(
-        pt_dtype, ms_dtype, *inputs_args, **inputs_kwargs
-    )
-
-    if "hidden_dtype" in inspect.signature(pt_model.forward).parameters:
-        pt_inputs_kwargs.update({"hidden_dtype": PT_DTYPE_MAPPING[pt_dtype]})
-        ms_inputs_kwargs.update({"hidden_dtype": MS_DTYPE_MAPPING[ms_dtype]})
-    ms_inputs_kwargs["return_dict"] = False
-
-    with torch.no_grad():
-        pt_outputs = pt_model(*pt_inputs_args, **pt_inputs_kwargs)
-    ms_outputs = ms_model(*ms_inputs_args, **ms_inputs_kwargs)
-
-    if outputs_map:
-        pt_outputs_n = []
-        ms_outputs_n = []
-        for pt_key, ms_idx in outputs_map.items():
-            pt_output = getattr(pt_outputs, pt_key)
-            ms_output = ms_outputs[ms_idx]
-            if isinstance(pt_output, (list, tuple)):
-                pt_outputs_n += list(pt_output)
-                ms_outputs_n += list(ms_output)
-            else:
-                pt_outputs_n.append(pt_output)
-                ms_outputs_n.append(ms_output)
-        diffs = compute_diffs(pt_outputs_n, ms_outputs_n)
-    else:
-        diffs = compute_diffs(pt_outputs, ms_outputs)
-
-    THRESHOLD = DTYPE_AND_THRESHOLDS[ms_dtype]
-    assert (np.array(diffs) < THRESHOLD).all(), (
-        f"ms_dtype: {ms_dtype}, pt_type:{pt_dtype}, "
-        f"Outputs({np.array(diffs).tolist()}) has diff bigger than {THRESHOLD}"
-    )
+        THRESHOLD = DTYPE_AND_THRESHOLDS[ms_dtype]
+        assert (np.array(diffs) < THRESHOLD).all(), (
+            f"ms_dtype: {ms_dtype}, pt_type:{pt_dtype}, "
+            f"Outputs({np.array(diffs).tolist()}) has diff bigger than {THRESHOLD}"
+        )

--- a/tests/transformers_tests/models/visual_bert/test_modeling_visual_bert.py
+++ b/tests/transformers_tests/models/visual_bert/test_modeling_visual_bert.py
@@ -324,6 +324,7 @@ def test_named_modules(
     )
 
 
+@pytest.mark.slow
 def test_inference_vqa_coco_pre():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -357,6 +358,7 @@ def test_inference_vqa_coco_pre():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_vqa():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -387,6 +389,7 @@ def test_inference_vqa():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_nlvr():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -415,6 +418,7 @@ def test_inference_nlvr():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_vcr():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 

--- a/tests/transformers_tests/models/vitpose/test_modeling_vitpose.py
+++ b/tests/transformers_tests/models/vitpose/test_modeling_vitpose.py
@@ -143,7 +143,7 @@ VIT_POSE_CASES = [
             "pixel_values": inputs_dict["pixel_values"],
         },
         {
-            "heatmaps": 1,
+            "heatmaps": 0,
         },
     ],
 ]

--- a/tests/transformers_tests/models/x_clip/test_modeling_x_clip.py
+++ b/tests/transformers_tests/models/x_clip/test_modeling_x_clip.py
@@ -310,6 +310,7 @@ def prepare_video():
     return list(video)
 
 
+@pytest.mark.slow
 def test_inference():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 
@@ -335,6 +336,7 @@ def test_inference():
     assert (np.array(diffs) < THRESHOLD).all(), f"Output difference exceeds the threshold: {diffs} > {THRESHOLD}"
 
 
+@pytest.mark.slow
 def test_inference_interpolate_pos_encoding():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 

--- a/tests/transformers_tests/models/yolos/test_modeling_yolos.py
+++ b/tests/transformers_tests/models/yolos/test_modeling_yolos.py
@@ -184,6 +184,7 @@ def prepare_img():
     return image
 
 
+@pytest.mark.slow
 def test_inference_object_detection_head():
     THRESHOLD = DTYPE_AND_THRESHOLDS["fp32"]
 


### PR DESCRIPTION


## Fixes 

1. fix fast ut mapping error - `gptj` and `vitpose`

2. modeling file bugfix - `gpt_neox_janpanese`

3. add version check - `qwen3moe` should have `transformers.__version__ >= "4.51.0"`)

4. add `@pytest.mark.slow` marker for tests with weights loaded

   ```bash
   # command of running all tests of mindone.transformers model
   pytest tests/transformers_tests/models -v
   
   # command of running fast tests only
   pytest tests/transformers_tests/models -v -m "not slow"
   ```


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [x] Did you build and run the code without any errors?
- [x] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [x] Did you write any new necessary tests?

