### PR TITLE
fix(transformers) seamless_m4t ut bugs

### DIFF
--- a/tests/transformers_tests/models/seamless_m4t/test_modeling_seamless_m4t.py
+++ b/tests/transformers_tests/models/seamless_m4t/test_modeling_seamless_m4t.py
@@ -230,7 +230,7 @@ SEAMLESS_M4T_CASES = [
             inputs_dict_speech["labels"],
         ),
         {},
-        [1, 2],
+        [1, 2, 3],
         {
             "logits": 0,
             "encoder_last_hidden_state": 2,
@@ -249,7 +249,7 @@ SEAMLESS_M4T_CASES = [
             inputs_dict_speech["labels"],
         ),
         {},
-        [1, 2],
+        [1, 2, 3],
         {
             "logits": 0,
             "encoder_last_hidden_state": 2,
@@ -307,7 +307,7 @@ SEAMLESS_M4T_CASES = [
             inputs_dict_text["labels"],
         ),
         {},
-        [2, 3],
+        [0, 2, 3, 4],
         {
             "logits": 0,
             "encoder_last_hidden_state": 2,
@@ -364,7 +364,7 @@ def test_named_modules(
     ms_inputs_kwargs["return_dict"] = False
 
     pt_inputs_args = tuple(
-        tensor.to(PT_DTYPE_MAPPING[pt_dtype]).long() if i in inputs_type_idx else tensor.to(PT_DTYPE_MAPPING[pt_dtype])
+        tensor.long() if i in inputs_type_idx else tensor.to(PT_DTYPE_MAPPING[pt_dtype])
         for i, tensor in enumerate(pt_inputs_args)
     )
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Fixes
The torch-version `Seamless_m4t` modules will raise "RuntimeError: mixed dtype (CPU): all inputs must share the same datatype", in the case when passing inputs with float datatype. 
It can be directly avoided by changing `hidden_states = self.layer_norm(hidden_states)` 
  to `hidden_states = self.layer_norm(hidden_states.to(self.layer_norm.weight.dtype))` 
  in `seamless_m4t/modeling_seamless_m4t.py`.
But, instead of changing the HF codes, a mask is designed to enforce the type conversion (from float to int) in UTs. 

## Notes
Refer to #1293 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [x] Did you build and run the code without any errors?
- [x] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
