### PR TITLE
fix(transformers/ut): fix compute_diffs Division by zero check

### DIFF
--- a/tests/modeling_test_utils.py
+++ b/tests/modeling_test_utils.py
@@ -379,7 +379,7 @@ def compute_diffs(pt_outputs: Union[torch.Tensor, np.ndarray], ms_outputs: Union
             # dist(x, y) := ||x - y|| / ||y||, where ||·|| means Frobenius norm
 
             # adaption for tensor with all zeros element
-            eps = 1e-9 if np.linalg.norm(p) == 0 else 0
+            eps = 1e-9 if np.isclose(np.linalg.norm(p), 0, atol=1e-9) else 0
             d = np.linalg.norm(p - m) / (np.linalg.norm(p) + eps)
             diffs.append(d)
 


### PR DESCRIPTION
# Fix
 fix compute_diffs Division by zero check
- before ```eps = 1e-9 if np.all(m.astype(np.float32) == 0) and np.all(p.astype(np.float32) == 0) else 0```
- after```eps = 1e-9 if np.linalg.norm(p) == 0 else 0```