### PR TITLE
feat: add text encoder files

### DIFF
--- a/mindone/comfyui/comfy/text_encoders/bert.py
+++ b/mindone/comfyui/comfy/text_encoders/bert.py
@@ -1,0 +1,200 @@
+import comfy.ops
+from comfy.ldm.modules.attention import optimized_attention_for_device
+from mindspore_patch.utils import dtype_to_max
+
+import mindspore
+from mindspore import mint
+
+
+class BertAttention(mindspore.nn.Cell):
+    def __init__(self, embed_dim, heads, dtype, device, operations):
+        super().__init__()
+
+        self.heads = heads
+        self.query = operations.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=None)
+        self.key = operations.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=None)
+        self.value = operations.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=None)
+
+    def construct(self, x, mask=None, optimized_attention=None):
+        q = self.query(x)
+        k = self.key(x)
+        v = self.value(x)
+
+        out = optimized_attention(q, k, v, self.heads, mask)
+        return out
+
+
+class BertOutput(mindspore.nn.Cell):
+    def __init__(self, input_dim, output_dim, layer_norm_eps, dtype, device, operations):
+        super().__init__()
+        self.dense = operations.Linear(input_dim, output_dim, dtype=dtype, device=None)
+        self.LayerNorm = operations.LayerNorm(output_dim, eps=layer_norm_eps, dtype=dtype, device=None)
+        # self.dropout = nn.Dropout(0.0)
+
+    def construct(self, x, y):
+        x = self.dense(x)
+        # hidden_states = self.dropout(hidden_states)
+        x = self.LayerNorm(x + y)
+        return x
+
+
+class BertAttentionBlock(mindspore.nn.Cell):
+    def __init__(self, embed_dim, heads, layer_norm_eps, dtype, device, operations):
+        super().__init__()
+        self.self = BertAttention(embed_dim, heads, dtype, None, operations)
+        self.output = BertOutput(embed_dim, embed_dim, layer_norm_eps, dtype, None, operations)
+
+    def construct(self, x, mask, optimized_attention):
+        y = self.self(x, mask, optimized_attention)
+        return self.output(y, x)
+
+
+class BertIntermediate(mindspore.nn.Cell):
+    def __init__(self, embed_dim, intermediate_dim, dtype, device, operations):
+        super().__init__()
+        self.dense = operations.Linear(embed_dim, intermediate_dim, dtype=dtype, device=None)
+
+    def construct(self, x):
+        x = self.dense(x)
+        return mint.functional.gelu(x)
+
+
+class BertBlock(mindspore.nn.Cell):
+    def __init__(self, embed_dim, intermediate_dim, heads, layer_norm_eps, dtype, device, operations):
+        super().__init__()
+        self.attention = BertAttentionBlock(embed_dim, heads, layer_norm_eps, dtype, None, operations)
+        self.intermediate = BertIntermediate(embed_dim, intermediate_dim, dtype, None, operations)
+        self.output = BertOutput(intermediate_dim, embed_dim, layer_norm_eps, dtype, None, operations)
+
+    def construct(self, x, mask, optimized_attention):
+        x = self.attention(x, mask, optimized_attention)
+        y = self.intermediate(x)
+        return self.output(y, x)
+
+
+class BertEncoder(mindspore.nn.Cell):
+    def __init__(self, num_layers, embed_dim, intermediate_dim, heads, layer_norm_eps, dtype, device, operations):
+        super().__init__()
+        self.layer = mindspore.nn.CellList(
+            [
+                BertBlock(embed_dim, intermediate_dim, heads, layer_norm_eps, dtype, None, operations)
+                for i in range(num_layers)
+            ]
+        )
+
+    def construct(self, x, mask=None, intermediate_output=None):
+        optimized_attention = optimized_attention_for_device(None, mask=mask is not None, small_input=True)
+
+        if intermediate_output is not None:
+            if intermediate_output < 0:
+                intermediate_output = len(self.layer) + intermediate_output
+
+        intermediate = None
+        for i, l in enumerate(self.layer):
+            x = l(x, mask, optimized_attention)
+            if i == intermediate_output:
+                intermediate = x.clone()
+        return x, intermediate
+
+
+class BertEmbeddings(mindspore.nn.Cell):
+    def __init__(
+        self,
+        vocab_size,
+        max_position_embeddings,
+        type_vocab_size,
+        pad_token_id,
+        embed_dim,
+        layer_norm_eps,
+        dtype,
+        device,
+        operations,
+    ):
+        super().__init__()
+        self.word_embeddings = operations.Embedding(
+            vocab_size, embed_dim, padding_idx=pad_token_id, dtype=dtype, device=None
+        )
+        self.position_embeddings = operations.Embedding(max_position_embeddings, embed_dim, dtype=dtype, device=None)
+        self.token_type_embeddings = operations.Embedding(type_vocab_size, embed_dim, dtype=dtype, device=None)
+
+        self.LayerNorm = operations.LayerNorm(embed_dim, eps=layer_norm_eps, dtype=dtype, device=None)
+
+    def construct(self, input_tokens, embeds=None, token_type_ids=None, dtype=None):
+        if embeds is not None:
+            x = embeds
+        else:
+            x = self.word_embeddings(input_tokens, out_dtype=dtype)
+        x += comfy.ops.cast_to_input(self.position_embeddings.weight[: x.shape[1]], x)
+        if token_type_ids is not None:
+            x += self.token_type_embeddings(token_type_ids, out_dtype=x.dtype)
+        else:
+            x += comfy.ops.cast_to_input(self.token_type_embeddings.weight[0], x)
+        x = self.LayerNorm(x)
+        return x
+
+
+class BertModel_(mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        embed_dim = config_dict["hidden_size"]
+        layer_norm_eps = config_dict["layer_norm_eps"]
+
+        self.embeddings = BertEmbeddings(
+            config_dict["vocab_size"],
+            config_dict["max_position_embeddings"],
+            config_dict["type_vocab_size"],
+            config_dict["pad_token_id"],
+            embed_dim,
+            layer_norm_eps,
+            dtype,
+            None,
+            operations,
+        )
+        self.encoder = BertEncoder(
+            config_dict["num_hidden_layers"],
+            embed_dim,
+            config_dict["intermediate_size"],
+            config_dict["num_attention_heads"],
+            layer_norm_eps,
+            dtype,
+            None,
+            operations,
+        )
+
+    def construct(
+        self,
+        input_tokens,
+        attention_mask=None,
+        embeds=None,
+        num_tokens=None,
+        intermediate_output=None,
+        final_layer_norm_intermediate=True,
+        dtype=None,
+        embeds_info=[],
+    ):
+        x = self.embeddings(input_tokens, embeds=embeds, dtype=dtype)
+        mask = None
+        if attention_mask is not None:
+            mask = 1.0 - attention_mask.to(x.dtype).reshape(
+                (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
+            ).expand((attention_mask.shape[0], 1, attention_mask.shape[-1], attention_mask.shape[-1]))
+            mask = mask.masked_fill(mask.to(mindspore.bool), -dtype_to_max(x.dtype))
+
+        x, i = self.encoder(x, mask, intermediate_output)
+        return x, i
+
+
+class BertModel(mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        self.bert = BertModel_(config_dict, dtype, None, operations)
+        self.num_layers = config_dict["num_hidden_layers"]
+
+    def get_input_embeddings(self):
+        return self.bert.embeddings.word_embeddings
+
+    def set_input_embeddings(self, embeddings):
+        self.bert.embeddings.word_embeddings = embeddings
+
+    def construct(self, *args, **kwargs):
+        return self.bert(*args, **kwargs)

--- a/mindone/comfyui/comfy/text_encoders/flux.py
+++ b/mindone/comfyui/comfy/text_encoders/flux.py
@@ -1,0 +1,91 @@
+import os
+
+import comfy.model_management
+import comfy.text_encoders.sd3_clip
+import comfy.text_encoders.t5
+from comfy import sd1_clip
+from transformers import T5TokenizerFast
+
+import mindspore
+from mindspore import mint
+
+
+class T5XXLTokenizer(sd1_clip.SDTokenizer):
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_tokenizer")
+        super().__init__(
+            tokenizer_path,
+            embedding_directory=embedding_directory,
+            pad_with_end=False,
+            embedding_size=4096,
+            embedding_key="t5xxl",
+            tokenizer_class=T5TokenizerFast,
+            has_start_token=False,
+            pad_to_max_length=False,
+            max_length=99999999,
+            min_length=256,
+            tokenizer_data=tokenizer_data,
+        )
+
+
+class FluxTokenizer:
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+        self.t5xxl = T5XXLTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+
+    def tokenize_with_weights(self, text: str, return_word_ids=False, **kwargs):
+        out = {}
+        out["l"] = self.clip_l.tokenize_with_weights(text, return_word_ids, **kwargs)
+        out["t5xxl"] = self.t5xxl.tokenize_with_weights(text, return_word_ids, **kwargs)
+        return out
+
+    def untokenize(self, token_weight_pair):
+        return self.clip_l.untokenize(token_weight_pair)
+
+    def state_dict(self):
+        return {}
+
+
+class FluxClipModel(mindspore.nn.Cell):
+    def __init__(self, dtype_t5=None, device=None, dtype=None, model_options={}):
+        super().__init__()
+        dtype_t5 = comfy.model_management.pick_weight_dtype(dtype_t5, dtype)
+        self.clip_l = sd1_clip.SDClipModel(dtype=dtype, return_projected_pooled=False, model_options=model_options)
+        self.t5xxl = comfy.text_encoders.sd3_clip.T5XXLModel(dtype=dtype_t5, model_options=model_options)
+        self.dtypes = set([dtype, dtype_t5])
+
+    def set_clip_options(self, options):
+        self.clip_l.set_clip_options(options)
+        self.t5xxl.set_clip_options(options)
+
+    def reset_clip_options(self):
+        self.clip_l.reset_clip_options()
+        self.t5xxl.reset_clip_options()
+
+    def encode_token_weights(self, token_weight_pairs):
+        token_weight_pairs_l = token_weight_pairs["l"]
+        token_weight_pairs_t5 = token_weight_pairs["t5xxl"]
+
+        t5_out, t5_pooled = self.t5xxl.encode_token_weights(token_weight_pairs_t5)
+        l_out, l_pooled = self.clip_l.encode_token_weights(token_weight_pairs_l)
+        return t5_out, l_pooled
+
+    def load_sd(self, sd):
+        if "text_model.encoder.layers.1.mlp.fc1.weight" in sd:
+            sd = {f"clip_l.transformer.{k}": v for k, v in sd.items()}
+            return self.clip_l.load_sd(sd)
+        else:
+            sd = {f"t5xxl.transformer.{k}": v for k, v in sd.items()}
+            return self.t5xxl.load_sd(sd)
+
+
+def flux_clip(dtype_t5=None, t5xxl_scaled_fp8=None):
+    class FluxClipModel_(FluxClipModel):
+        def __init__(self, device=None, dtype=None, model_options={}):
+            if t5xxl_scaled_fp8 is not None and "t5xxl_scaled_fp8" not in model_options:
+                # model_options = model_options.copy()
+                # model_options["t5xxl_scaled_fp8"] = t5xxl_scaled_fp8
+                raise NotImplementedError
+            super().__init__(dtype_t5=dtype_t5, device=None, dtype=dtype, model_options=model_options)
+
+    return FluxClipModel_

--- a/mindone/comfyui/comfy/text_encoders/hunyuan_video.py
+++ b/mindone/comfyui/comfy/text_encoders/hunyuan_video.py
@@ -1,0 +1,213 @@
+import numbers
+import os
+
+import comfy.model_management
+import comfy.text_encoders.llama
+from comfy import sd1_clip
+from transformers import LlamaTokenizerFast
+
+import mindspore
+
+
+def llama_detect(state_dict, prefix=""):
+    out = {}
+    t5_key = "{}model.norm.weight".format(prefix)
+    if t5_key in state_dict:
+        out["dtype_llama"] = state_dict[t5_key].dtype
+
+    scaled_fp8_key = "{}scaled_fp8".format(prefix)
+    if scaled_fp8_key in state_dict:
+        out["llama_scaled_fp8"] = state_dict[scaled_fp8_key].dtype
+
+    return out
+
+
+class LLAMA3Tokenizer(sd1_clip.SDTokenizer):
+    def __init__(self, embedding_directory=None, tokenizer_data={}, min_length=256, pad_token=128258):
+        tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "llama_tokenizer")
+        super().__init__(
+            tokenizer_path,
+            embedding_directory=embedding_directory,
+            pad_with_end=False,
+            embedding_size=4096,
+            embedding_key="llama",
+            tokenizer_class=LlamaTokenizerFast,
+            has_start_token=True,
+            has_end_token=False,
+            pad_to_max_length=False,
+            max_length=99999999,
+            pad_token=pad_token,
+            min_length=min_length,
+            tokenizer_data=tokenizer_data,
+        )
+
+
+class LLAMAModel(sd1_clip.SDClipModel):
+    def __init__(
+        self,
+        device=None,
+        layer="hidden",
+        layer_idx=-3,
+        dtype=None,
+        attention_mask=True,
+        model_options={},
+        special_tokens={"start": 128000, "pad": 128258},
+    ):
+        llama_scaled_fp8 = model_options.get("llama_scaled_fp8", None)
+        if llama_scaled_fp8 is not None:
+            model_options = model_options.copy()
+            model_options["scaled_fp8"] = llama_scaled_fp8
+
+        textmodel_json_config = {}
+        vocab_size = model_options.get("vocab_size", None)
+        if vocab_size is not None:
+            textmodel_json_config["vocab_size"] = vocab_size
+
+        model_options = {**model_options, "model_name": "llama"}
+        super().__init__(
+            device=None,
+            layer=layer,
+            layer_idx=layer_idx,
+            textmodel_json_config=textmodel_json_config,
+            dtype=dtype,
+            special_tokens=special_tokens,
+            layer_norm_hidden_state=False,
+            model_class=comfy.text_encoders.llama.Llama2,
+            enable_attention_masks=attention_mask,
+            return_attention_masks=attention_mask,
+            model_options=model_options,
+        )
+
+
+class HunyuanVideoTokenizer:
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+        self.llama_template = """<|start_header_id|>system<|end_header_id|>\n\nDescribe the video by detailing the following aspects: 1. The main content and theme of the video.2. The color, shape, size, texture, quantity, text, and spatial relationships of the objects.3. Actions, events, behaviors temporal relationships, physical movement changes of the objects.4. background environment, light, style and atmosphere.5. camera angles, movements, and transitions used in the video:<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n{}<|eot_id|>"""  # 95 tokens
+        self.llama = LLAMA3Tokenizer(
+            embedding_directory=embedding_directory, min_length=1, tokenizer_data=tokenizer_data
+        )
+
+    def tokenize_with_weights(
+        self, text, return_word_ids=False, llama_template=None, image_embeds=None, image_interleave=1, **kwargs
+    ):
+        out = {}
+        out["l"] = self.clip_l.tokenize_with_weights(text, return_word_ids, **kwargs)
+
+        if llama_template is None:
+            llama_text = self.llama_template.format(text)
+        else:
+            llama_text = llama_template.format(text)
+        llama_text_tokens = self.llama.tokenize_with_weights(llama_text, return_word_ids, **kwargs)
+        embed_count = 0
+        for r in llama_text_tokens:
+            for i in range(len(r)):
+                if r[i][0] == 128257:
+                    if image_embeds is not None and embed_count < image_embeds.shape[0]:
+                        r[i] = (
+                            {
+                                "type": "embedding",
+                                "data": image_embeds[embed_count],
+                                "original_type": "image",
+                                "image_interleave": image_interleave,
+                            },
+                        ) + r[i][1:]
+                        embed_count += 1
+        out["llama"] = llama_text_tokens
+        return out
+
+    def untokenize(self, token_weight_pair):
+        return self.clip_l.untokenize(token_weight_pair)
+
+    def state_dict(self):
+        return {}
+
+
+class HunyuanVideoClipModel(mindspore.nn.Cell):
+    def __init__(self, dtype_llama=None, device=None, dtype=None, model_options={}):
+        super().__init__()
+        dtype_llama = comfy.model_management.pick_weight_dtype(dtype_llama, dtype, device)
+        self.clip_l = sd1_clip.SDClipModel(
+            device=None, dtype=dtype, return_projected_pooled=False, model_options=model_options
+        )
+        self.llama = LLAMAModel(device=None, dtype=dtype_llama, model_options=model_options)
+        self.dtypes = set([dtype, dtype_llama])
+
+    def set_clip_options(self, options):
+        self.clip_l.set_clip_options(options)
+        self.llama.set_clip_options(options)
+
+    def reset_clip_options(self):
+        self.clip_l.reset_clip_options()
+        self.llama.reset_clip_options()
+
+    def encode_token_weights(self, token_weight_pairs):
+        token_weight_pairs_l = token_weight_pairs["l"]
+        token_weight_pairs_llama = token_weight_pairs["llama"]
+
+        llama_out, llama_pooled, llama_extra_out = self.llama.encode_token_weights(token_weight_pairs_llama)
+
+        template_end = 0
+        extra_template_end = 0
+        extra_sizes = 0
+        user_end = 9999999999999
+        images = []
+
+        tok_pairs = token_weight_pairs_llama[0]
+        for i, v in enumerate(tok_pairs):
+            elem = v[0]
+            if not mindspore.is_tensor(elem):
+                if isinstance(elem, numbers.Integral):
+                    if elem == 128006:
+                        if tok_pairs[i + 1][0] == 882:
+                            if tok_pairs[i + 2][0] == 128007:
+                                template_end = i + 2
+                                user_end = -1
+                    if elem == 128009 and user_end == -1:
+                        user_end = i + 1
+                else:
+                    if elem.get("original_type") == "image":
+                        elem_size = elem.get("data").shape[0]
+                        if template_end > 0:
+                            if user_end == -1:
+                                extra_template_end += elem_size - 1
+                        else:
+                            image_start = i + extra_sizes
+                            image_end = i + elem_size + extra_sizes
+                            images.append((image_start, image_end, elem.get("image_interleave", 1)))
+                            extra_sizes += elem_size - 1
+
+        if llama_out.shape[1] > (template_end + 2):
+            if tok_pairs[template_end + 1][0] == 271:
+                template_end += 2
+        llama_output = llama_out[:, template_end + extra_sizes : user_end + extra_sizes + extra_template_end]
+        llama_extra_out["attention_mask"] = llama_extra_out["attention_mask"][
+            :, template_end + extra_sizes : user_end + extra_sizes + extra_template_end
+        ]
+        if llama_extra_out["attention_mask"].sum() == mindspore.ops.numel(llama_extra_out["attention_mask"]):
+            llama_extra_out.pop("attention_mask")  # attention mask is useless if no masked elements
+
+        if len(images) > 0:
+            out = []
+            for i in images:
+                out.append(llama_out[:, i[0] : i[1] : i[2]])
+            llama_output = mindspore.mint.cat(out + [llama_output], dim=1)
+
+        l_out, l_pooled = self.clip_l.encode_token_weights(token_weight_pairs_l)
+        return llama_output, l_pooled, llama_extra_out
+
+    def load_sd(self, sd):
+        if "text_model.encoder.layers.1.mlp.fc1.weight" in sd:
+            return self.clip_l.load_sd(sd)
+        else:
+            return self.llama.load_sd(sd)
+
+
+def hunyuan_video_clip(dtype_llama=None, llama_scaled_fp8=None):
+    class HunyuanVideoClipModel_(HunyuanVideoClipModel):
+        def __init__(self, device=None, dtype=None, model_options={}):
+            if llama_scaled_fp8 is not None and "llama_scaled_fp8" not in model_options:
+                model_options = model_options.copy()
+                model_options["llama_scaled_fp8"] = llama_scaled_fp8
+            super().__init__(dtype_llama=dtype_llama, device=None, dtype=dtype, model_options=model_options)
+
+    return HunyuanVideoClipModel_

--- a/mindone/comfyui/comfy/text_encoders/llama.py
+++ b/mindone/comfyui/comfy/text_encoders/llama.py
@@ -1,0 +1,598 @@
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import comfy.ldm.common_dit
+import comfy.model_management
+from comfy.ldm.modules.attention import optimized_attention_for_device
+
+import mindspore
+from mindspore import mint, nn
+
+from . import qwen_vl
+
+
+@dataclass
+class Llama2Config:
+    vocab_size: int = 128320
+    hidden_size: int = 4096
+    intermediate_size: int = 14336
+    num_hidden_layers: int = 32
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    max_position_embeddings: int = 8192
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 500000.0
+    transformer_type: str = "llama"
+    head_dim = 128
+    rms_norm_add = False
+    mlp_activation = "silu"
+    qkv_bias = False
+    rope_dims = None
+    q_norm = None
+    k_norm = None
+    rope_scale = None
+
+
+@dataclass
+class Qwen25_3BConfig:
+    vocab_size: int = 151936
+    hidden_size: int = 2048
+    intermediate_size: int = 11008
+    num_hidden_layers: int = 36
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 2
+    max_position_embeddings: int = 128000
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+    transformer_type: str = "llama"
+    head_dim = 128
+    rms_norm_add = False
+    mlp_activation = "silu"
+    qkv_bias = True
+    rope_dims = None
+    q_norm = None
+    k_norm = None
+    rope_scale = None
+
+
+@dataclass
+class Qwen25_7BVLI_Config:
+    vocab_size: int = 152064
+    hidden_size: int = 3584
+    intermediate_size: int = 18944
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 28
+    num_key_value_heads: int = 4
+    max_position_embeddings: int = 128000
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+    transformer_type: str = "llama"
+    head_dim = 128
+    rms_norm_add = False
+    mlp_activation = "silu"
+    qkv_bias = True
+    rope_dims = [16, 24, 24]
+    q_norm = None
+    k_norm = None
+    rope_scale = None
+
+
+@dataclass
+class Gemma2_2B_Config:
+    vocab_size: int = 256000
+    hidden_size: int = 2304
+    intermediate_size: int = 9216
+    num_hidden_layers: int = 26
+    num_attention_heads: int = 8
+    num_key_value_heads: int = 4
+    max_position_embeddings: int = 8192
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    transformer_type: str = "gemma2"
+    head_dim = 256
+    rms_norm_add = True
+    mlp_activation = "gelu_pytorch_tanh"
+    qkv_bias = False
+    rope_dims = None
+    q_norm = None
+    k_norm = None
+    sliding_attention = None
+    rope_scale = None
+
+
+@dataclass
+class Gemma3_4B_Config:
+    vocab_size: int = 262208
+    hidden_size: int = 2560
+    intermediate_size: int = 10240
+    num_hidden_layers: int = 34
+    num_attention_heads: int = 8
+    num_key_value_heads: int = 4
+    max_position_embeddings: int = 131072
+    rms_norm_eps: float = 1e-6
+    rope_theta = [10000.0, 1000000.0]
+    transformer_type: str = "gemma3"
+    head_dim = 256
+    rms_norm_add = True
+    mlp_activation = "gelu_pytorch_tanh"
+    qkv_bias = False
+    rope_dims = None
+    q_norm = "gemma3"
+    k_norm = "gemma3"
+    sliding_attention = [False, False, False, False, False, 1024]
+    rope_scale = [1.0, 8.0]
+
+
+class RMSNorm(nn.Cell):
+    def __init__(self, dim: int, eps: float = 1e-5, add=False, device=None, dtype=None):
+        super().__init__()
+        self.eps = eps
+        self.weight = mindspore.Parameter(mint.empty(dim, dtype=dtype))
+        self.add = add
+
+    def construct(self, x: mindspore.Tensor):
+        w = self.weight
+        if self.add:
+            w = w + 1.0
+
+        return comfy.ldm.common_dit.rms_norm(x, w, self.eps)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return mint.cat((-x2, x1), dim=-1)
+
+
+def precompute_freqs_cis(head_dim, position_ids, theta, rope_scale=None, rope_dims=None, device=None):
+    if not isinstance(theta, list):
+        theta = [theta]
+
+    out = []
+    for index, t in enumerate(theta):
+        theta_numerator = mint.arange(0, head_dim, 2).float()
+        inv_freq = 1.0 / (t ** (theta_numerator / head_dim))
+
+        if rope_scale is not None:
+            if isinstance(rope_scale, list):
+                inv_freq /= rope_scale[index]
+            else:
+                inv_freq /= rope_scale
+
+        inv_freq_expanded = inv_freq[None, :, None].float().expand((position_ids.shape[0], -1, 1))
+        position_ids_expanded = position_ids[:, None, :].float()
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = mint.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+        if rope_dims is not None and position_ids.shape[0] > 1:
+            mrope_section = rope_dims * 2
+            cos = mint.cat([m[i % 3] for i, m in enumerate(cos.split(mrope_section, dim=-1))], dim=-1).unsqueeze(0)
+            sin = mint.cat([m[i % 3] for i, m in enumerate(sin.split(mrope_section, dim=-1))], dim=-1).unsqueeze(0)
+        else:
+            cos = cos.unsqueeze(1)
+            sin = sin.unsqueeze(1)
+        out.append((cos, sin))
+
+    if len(out) == 1:
+        return out[0]
+
+    return out
+
+
+def apply_rope(xq, xk, freqs_cis):
+    org_dtype = xq.dtype
+    cos = freqs_cis[0]
+    sin = freqs_cis[1]
+    q_embed = (xq * cos) + (rotate_half(xq) * sin)
+    k_embed = (xk * cos) + (rotate_half(xk) * sin)
+    return q_embed.to(org_dtype), k_embed.to(org_dtype)
+
+
+class Attention(nn.Cell):
+    def __init__(self, config: Llama2Config, device=None, dtype=None, ops: Any = None):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.hidden_size = config.hidden_size
+
+        self.head_dim = config.head_dim
+        self.inner_size = self.num_heads * self.head_dim
+
+        ops = ops or nn
+        self.q_proj = ops.Linear(config.hidden_size, self.inner_size, bias=config.qkv_bias, dtype=dtype)
+        self.k_proj = ops.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=config.qkv_bias, dtype=dtype
+        )
+        self.v_proj = ops.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=config.qkv_bias, dtype=dtype
+        )
+        self.o_proj = ops.Linear(self.inner_size, config.hidden_size, bias=False, dtype=dtype)
+
+        self.q_norm = None
+        self.k_norm = None
+
+        if config.q_norm == "gemma3":
+            self.q_norm = RMSNorm(
+                self.head_dim, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+            )
+        if config.k_norm == "gemma3":
+            self.k_norm = RMSNorm(
+                self.head_dim, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+            )
+
+    def construct(
+        self,
+        hidden_states: mindspore.Tensor,
+        attention_mask: Optional[mindspore.Tensor] = None,
+        freqs_cis: Optional[mindspore.Tensor] = None,
+        optimized_attention=None,
+    ):
+        batch_size, seq_length, _ = hidden_states.shape
+        xq = self.q_proj(hidden_states)
+        xk = self.k_proj(hidden_states)
+        xv = self.v_proj(hidden_states)
+
+        xq = xq.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+        xk = xk.view(batch_size, seq_length, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        xv = xv.view(batch_size, seq_length, self.num_kv_heads, self.head_dim).transpose(1, 2)
+
+        if self.q_norm is not None:
+            xq = self.q_norm(xq)
+        if self.k_norm is not None:
+            xk = self.k_norm(xk)
+
+        xq, xk = apply_rope(xq, xk, freqs_cis=freqs_cis)
+
+        xk = xk.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
+        xv = xv.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
+
+        output = optimized_attention(xq, xk, xv, self.num_heads, mask=attention_mask, skip_reshape=True)
+        return self.o_proj(output)
+
+
+class MLP(nn.Cell):
+    def __init__(self, config: Llama2Config, device=None, dtype=None, ops: Any = None):
+        super().__init__()
+        ops = ops or nn
+        self.gate_proj = ops.Linear(config.hidden_size, config.intermediate_size, bias=False, dtype=dtype)
+        self.up_proj = ops.Linear(config.hidden_size, config.intermediate_size, bias=False, dtype=dtype)
+        self.down_proj = ops.Linear(config.intermediate_size, config.hidden_size, bias=False, dtype=dtype)
+        if config.mlp_activation == "silu":
+            self.activation = mint.nn.functional.silu
+        elif config.mlp_activation == "gelu_pytorch_tanh":
+            self.activation = lambda a: mint.nn.functional.gelu(a, approximate="tanh")
+
+    def construct(self, x):
+        return self.down_proj(self.activation(self.gate_proj(x)) * self.up_proj(x))
+
+
+class TransformerBlock(nn.Cell):
+    def __init__(self, config: Llama2Config, index, device=None, dtype=None, ops: Any = None):
+        super().__init__()
+        self.self_attn = Attention(config, device=None, dtype=dtype, ops=ops)
+        self.mlp = MLP(config, device=None, dtype=dtype, ops=ops)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, device=None, dtype=dtype)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, device=None, dtype=dtype)
+
+    def construct(
+        self,
+        x: mindspore.Tensor,
+        attention_mask: Optional[mindspore.Tensor] = None,
+        freqs_cis: Optional[mindspore.Tensor] = None,
+        optimized_attention=None,
+    ):
+        # Self Attention
+        residual = x
+        x = self.input_layernorm(x)
+        x = self.self_attn(
+            hidden_states=x,
+            attention_mask=attention_mask,
+            freqs_cis=freqs_cis,
+            optimized_attention=optimized_attention,
+        )
+        x = residual + x
+
+        # MLP
+        residual = x
+        x = self.post_attention_layernorm(x)
+        x = self.mlp(x)
+        x = residual + x
+
+        return x
+
+
+class TransformerBlockGemma2(nn.Cell):
+    def __init__(self, config: Llama2Config, index, device=None, dtype=None, ops: Any = None):
+        super().__init__()
+        self.self_attn = Attention(config, device=None, dtype=dtype, ops=ops)
+        self.mlp = MLP(config, device=None, dtype=dtype, ops=ops)
+        self.input_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+        )
+        self.pre_feedforward_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+        )
+        self.post_feedforward_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+        )
+
+        if (
+            config.sliding_attention is not None
+        ):  # TODO: implement. (Not that necessary since models are trained on less than 1024 tokens)
+            self.sliding_attention = config.sliding_attention[index % len(config.sliding_attention)]
+        else:
+            self.sliding_attention = False
+
+        self.transformer_type = config.transformer_type
+
+    def construct(
+        self,
+        x: mindspore.Tensor,
+        attention_mask: Optional[mindspore.Tensor] = None,
+        freqs_cis: Optional[mindspore.Tensor] = None,
+        optimized_attention=None,
+    ):
+        if self.transformer_type == "gemma3":
+            if self.sliding_attention:
+                if x.shape[1] > self.sliding_attention:
+                    logging.warning("Warning: sliding attention not implemented, results may be incorrect")
+                freqs_cis = freqs_cis[1]
+            else:
+                freqs_cis = freqs_cis[0]
+
+        # Self Attention
+        residual = x
+        x = self.input_layernorm(x)
+        x = self.self_attn(
+            hidden_states=x,
+            attention_mask=attention_mask,
+            freqs_cis=freqs_cis,
+            optimized_attention=optimized_attention,
+        )
+
+        x = self.post_attention_layernorm(x)
+        x = residual + x
+
+        # MLP
+        residual = x
+        x = self.pre_feedforward_layernorm(x)
+        x = self.mlp(x)
+        x = self.post_feedforward_layernorm(x)
+        x = residual + x
+
+        return x
+
+
+class Llama2_(nn.Cell):
+    def __init__(self, config, device=None, dtype=None, ops=None):
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = ops.Embedding(config.vocab_size, config.hidden_size, dtype=dtype)
+        if self.config.transformer_type == "gemma2" or self.config.transformer_type == "gemma3":
+            transformer = TransformerBlockGemma2
+            self.normalize_in = True
+        else:
+            transformer = TransformerBlock
+            self.normalize_in = False
+
+        self.layers = nn.CellList(
+            [transformer(config, index=i, device=None, dtype=dtype, ops=ops) for i in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, add=config.rms_norm_add, device=None, dtype=dtype
+        )
+        # self.lm_head = ops.Linear(config.hidden_size, config.vocab_size, bias=False, device=None, dtype=dtype)
+
+    def construct(
+        self,
+        x,
+        attention_mask=None,
+        embeds=None,
+        num_tokens=None,
+        intermediate_output=None,
+        final_layer_norm_intermediate=True,
+        dtype=None,
+        position_ids=None,
+        embeds_info=[],
+    ):
+        if embeds is not None:
+            x = embeds
+        else:
+            x = self.embed_tokens(x, out_dtype=dtype)
+
+        if self.normalize_in:
+            x *= self.config.hidden_size**0.5
+
+        if position_ids is None:
+            position_ids = mint.arange(0, x.shape[1]).unsqueeze(0)
+
+        freqs_cis = precompute_freqs_cis(
+            self.config.head_dim,
+            position_ids,
+            self.config.rope_theta,
+            self.config.rope_scale,
+            self.config.rope_dims,
+            None,
+        )
+
+        mask = None
+        if attention_mask is not None:
+            mask = 1.0 - attention_mask.to(x.dtype).reshape(
+                (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
+            ).expand((attention_mask.shape[0], 1, attention_mask.shape[-1], attention_mask.shape[-1]))
+            mask = mask.masked_fill(mask.to(mindspore.bool), float("-inf"))
+
+        causal_mask = mint.triu(mint.empty(x.shape[1], x.shape[1], dtype=x.dtype).fill_(float("-inf")), 1)
+        if mask is not None:
+            mask += causal_mask
+        else:
+            mask = causal_mask
+        optimized_attention = optimized_attention_for_device(None, mask=mask is not None, small_input=True)
+
+        intermediate = None
+        all_intermediate = None
+        if intermediate_output is not None:
+            if intermediate_output == "all":
+                all_intermediate = []
+                intermediate_output = None
+            elif intermediate_output < 0:
+                intermediate_output = len(self.layers) + intermediate_output
+
+        for i, layer in enumerate(self.layers):
+            if all_intermediate is not None:
+                all_intermediate.append(x.unsqueeze(1).clone())
+            x = layer(
+                x=x,
+                attention_mask=mask,
+                freqs_cis=freqs_cis,
+                optimized_attention=optimized_attention,
+            )
+            if i == intermediate_output:
+                intermediate = x.clone()
+
+        x = self.norm(x)
+        if all_intermediate is not None:
+            all_intermediate.append(x.unsqueeze(1).clone())
+
+        if all_intermediate is not None:
+            intermediate = mint.cat(all_intermediate, dim=1)
+
+        if intermediate is not None and final_layer_norm_intermediate:
+            intermediate = self.norm(intermediate)
+
+        return x, intermediate
+
+
+class BaseLlama:
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, embeddings):
+        self.model.embed_tokens = embeddings
+
+    def construct(self, input_ids, *args, **kwargs):
+        return self.model(input_ids, *args, **kwargs)
+
+
+class Llama2(BaseLlama, mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        config = Llama2Config(**config_dict)
+        self.num_layers = config.num_hidden_layers
+
+        self.model = Llama2_(config, device=None, dtype=dtype, ops=operations)
+        self.dtype = dtype
+
+
+class Qwen25_3B(BaseLlama, mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        config = Qwen25_3BConfig(**config_dict)
+        self.num_layers = config.num_hidden_layers
+
+        self.model = Llama2_(config, device=None, dtype=dtype, ops=operations)
+        self.dtype = dtype
+
+
+class Qwen25_7BVLI(BaseLlama, mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        config = Qwen25_7BVLI_Config(**config_dict)
+        self.num_layers = config.num_hidden_layers
+
+        self.model = Llama2_(config, device=None, dtype=dtype, ops=operations)
+        self.visual = qwen_vl.Qwen2VLVisionTransformer(
+            hidden_size=1280, output_hidden_size=config.hidden_size, device=None, dtype=dtype, ops=operations
+        )
+        self.dtype = dtype
+
+    def preprocess_embed(self, embed, device):
+        if embed["type"] == "image":
+            image, grid = qwen_vl.process_qwen2vl_images(embed["data"])
+            return self.visual(image.to(dtype=mindspore.float32), grid), grid
+        return None, None
+
+    def construct(
+        self,
+        x,
+        attention_mask=None,
+        embeds=None,
+        num_tokens=None,
+        intermediate_output=None,
+        final_layer_norm_intermediate=True,
+        dtype=None,
+        embeds_info=[],
+    ):
+        grid = None
+        position_ids = None
+        offset = 0
+        for e in embeds_info:
+            if e.get("type") == "image":
+                grid = e.get("extra", None)
+                start = e.get("index")
+                if position_ids is None:
+                    position_ids = mint.zeros((3, embeds.shape[1]))
+                    position_ids[:, :start] = mint.arange(0, start)
+                end = e.get("size") + start
+                len_max = int(grid.max()) // 2
+                start_next = len_max + start
+                position_ids[:, end:] = mint.arange(start_next + offset, start_next + (embeds.shape[1] - end) + offset)
+                position_ids[0, start:end] = start + offset
+                max_d = int(grid[0][1]) // 2
+                position_ids[1, start:end] = (
+                    mint.arange(start + offset, start + max_d + offset)
+                    .unsqueeze(1)
+                    .repeat(1, math.ceil((end - start) / max_d))
+                    .flatten(0)[: end - start]
+                )
+                max_d = int(grid[0][2]) // 2
+                position_ids[2, start:end] = (
+                    mint.arange(start + offset, start + max_d + offset)
+                    .unsqueeze(0)
+                    .repeat(math.ceil((end - start) / max_d), 1)
+                    .flatten(0)[: end - start]
+                )
+                offset += len_max - (end - start)
+
+        if grid is None:
+            position_ids = None
+
+        return super().construct(
+            x,
+            attention_mask=attention_mask,
+            embeds=embeds,
+            num_tokens=num_tokens,
+            intermediate_output=intermediate_output,
+            final_layer_norm_intermediate=final_layer_norm_intermediate,
+            dtype=dtype,
+            position_ids=position_ids,
+        )
+
+
+class Gemma2_2B(BaseLlama, mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        config = Gemma2_2B_Config(**config_dict)
+        self.num_layers = config.num_hidden_layers
+
+        self.model = Llama2_(config, device=None, dtype=dtype, ops=operations)
+        self.dtype = dtype
+
+
+class Gemma3_4B(BaseLlama, mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        config = Gemma3_4B_Config(**config_dict)
+        self.num_layers = config.num_hidden_layers
+
+        self.model = Llama2_(config, device=None, dtype=dtype, ops=operations)
+        self.dtype = dtype

--- a/mindone/comfyui/comfy/text_encoders/qwen_image.py
+++ b/mindone/comfyui/comfy/text_encoders/qwen_image.py
@@ -1,0 +1,134 @@
+import numbers
+import os
+
+import comfy.text_encoders.llama
+from comfy import sd1_clip
+from transformers import Qwen2Tokenizer
+
+import mindspore
+from mindspore import ops
+
+
+class Qwen25_7BVLITokenizer(sd1_clip.SDTokenizer):
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "qwen25_tokenizer")
+        super().__init__(
+            tokenizer_path,
+            pad_with_end=False,
+            embedding_size=3584,
+            embedding_key="qwen25_7b",
+            tokenizer_class=Qwen2Tokenizer,
+            has_start_token=False,
+            has_end_token=False,
+            pad_to_max_length=False,
+            max_length=99999999,
+            min_length=1,
+            pad_token=151643,
+            tokenizer_data=tokenizer_data,
+        )
+
+
+class QwenImageTokenizer(sd1_clip.SD1Tokenizer):
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        super().__init__(
+            embedding_directory=embedding_directory,
+            tokenizer_data=tokenizer_data,
+            name="qwen25_7b",
+            tokenizer=Qwen25_7BVLITokenizer,
+        )
+        self.llama_template = "<|im_start|>system\nDescribe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n<|im_start|>assistant\n"
+        self.llama_template_images = "<|im_start|>system\nDescribe the key features of the input image (color, shape, size, texture, objects, background), then explain how the user's text instruction should alter or modify the image. Generate a new image that meets the user's requirements while maintaining consistency with the original input where appropriate.<|im_end|>\n<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>{}<|im_end|>\n<|im_start|>assistant\n"
+
+    def tokenize_with_weights(self, text, return_word_ids=False, llama_template=None, images=[], **kwargs):
+        skip_template = False
+        if text.startswith("<|im_start|>"):
+            skip_template = True
+        if text.startswith("<|start_header_id|>"):
+            skip_template = True
+
+        if skip_template:
+            llama_text = text
+        else:
+            if llama_template is None:
+                if len(images) > 0:
+                    llama_text = self.llama_template_images.format(text)
+                else:
+                    llama_text = self.llama_template.format(text)
+            else:
+                llama_text = llama_template.format(text)
+        tokens = super().tokenize_with_weights(
+            llama_text, return_word_ids=return_word_ids, disable_weights=True, **kwargs
+        )
+        key_name = next(iter(tokens))
+        embed_count = 0
+        qwen_tokens = tokens[key_name]
+        for r in qwen_tokens:
+            for i in range(len(r)):
+                if r[i][0] == 151655:
+                    if len(images) > embed_count:
+                        r[i] = ({"type": "image", "data": images[embed_count], "original_type": "image"},) + r[i][1:]
+                        embed_count += 1
+        return tokens
+
+
+class Qwen25_7BVLIModel(sd1_clip.SDClipModel):
+    def __init__(self, device=None, layer="last", layer_idx=None, dtype=None, attention_mask=True, model_options={}):
+        super().__init__(
+            device=None,
+            layer=layer,
+            layer_idx=layer_idx,
+            textmodel_json_config={},
+            dtype=dtype,
+            special_tokens={"pad": 151643},
+            layer_norm_hidden_state=False,
+            model_class=comfy.text_encoders.llama.Qwen25_7BVLI,
+            enable_attention_masks=attention_mask,
+            return_attention_masks=attention_mask,
+            model_options=model_options,
+        )
+
+
+class QwenImageTEModel(sd1_clip.SD1ClipModel):
+    def __init__(self, device=None, dtype=None, model_options={}):
+        super().__init__(
+            device=None, dtype=dtype, name="qwen25_7b", clip_model=Qwen25_7BVLIModel, model_options=model_options
+        )
+
+    def encode_token_weights(self, token_weight_pairs, template_end=-1):
+        out, pooled, extra = super().encode_token_weights(token_weight_pairs)
+        tok_pairs = token_weight_pairs["qwen25_7b"][0]
+        count_im_start = 0
+        if template_end == -1:
+            for i, v in enumerate(tok_pairs):
+                elem = v[0]
+                if not mindspore.is_tensor(elem):
+                    if isinstance(elem, numbers.Integral):
+                        if elem == 151644 and count_im_start < 2:
+                            template_end = i
+                            count_im_start += 1
+
+            if out.shape[1] > (template_end + 3):
+                if tok_pairs[template_end + 1][0] == 872:
+                    if tok_pairs[template_end + 2][0] == 198:
+                        template_end += 3
+
+        out = out[:, template_end:]
+
+        extra["attention_mask"] = extra["attention_mask"][:, template_end:]
+        if extra["attention_mask"].sum() == ops.numel(extra["attention_mask"]):
+            extra.pop("attention_mask")  # attention mask is useless if no masked elements
+
+        return out, pooled, extra
+
+
+def te(dtype_llama=None, llama_scaled_fp8=None):
+    class QwenImageTEModel_(QwenImageTEModel):
+        def __init__(self, device=None, dtype=None, model_options={}):
+            if llama_scaled_fp8 is not None and "scaled_fp8" not in model_options:
+                model_options = model_options.copy()
+                model_options["scaled_fp8"] = llama_scaled_fp8
+            if dtype_llama is not None:
+                dtype = dtype_llama
+            super().__init__(device=None, dtype=dtype, model_options=model_options)
+
+    return QwenImageTEModel_

--- a/mindone/comfyui/comfy/text_encoders/qwen_vl.py
+++ b/mindone/comfyui/comfy/text_encoders/qwen_vl.py
@@ -1,0 +1,416 @@
+import math
+from typing import Optional, Tuple
+
+from comfy.ldm.modules.attention import optimized_attention_for_device
+
+import mindspore
+import mindspore.mint.nn.functional as F
+import mindspore.nn as nn
+from mindspore import mint
+
+
+def process_qwen2vl_images(
+    images: mindspore.Tensor,
+    min_pixels: int = 3136,
+    max_pixels: int = 12845056,
+    patch_size: int = 14,
+    temporal_patch_size: int = 2,
+    merge_size: int = 2,
+    image_mean: list = None,
+    image_std: list = None,
+):
+    if image_mean is None:
+        image_mean = [0.48145466, 0.4578275, 0.40821073]
+    if image_std is None:
+        image_std = [0.26862954, 0.26130258, 0.27577711]
+
+    batch_size, height, width, channels = images.shape
+    # dtype = images.dtype
+
+    images = images.permute(0, 3, 1, 2)
+
+    grid_thw_list = []
+    img = images[0]
+
+    factor = patch_size * merge_size
+
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, math.floor(height / beta / factor) * factor)
+        w_bar = max(factor, math.floor(width / beta / factor) * factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+
+    img_resized = F.interpolate(img.unsqueeze(0), size=(h_bar, w_bar), mode="bilinear", align_corners=False).squeeze(0)
+
+    normalized = img_resized.clone()
+    for c in range(3):
+        normalized[c] = (img_resized[c] - image_mean[c]) / image_std[c]
+
+    grid_h = h_bar // patch_size
+    grid_w = w_bar // patch_size
+    grid_thw = mindspore.tensor([1, grid_h, grid_w], dtype=mindspore.int64)
+
+    pixel_values = normalized
+    grid_thw_list.append(grid_thw)
+    image_grid_thw = mint.stack(grid_thw_list)
+
+    grid_t = 1
+    channel = pixel_values.shape[0]
+    pixel_values = pixel_values.unsqueeze(0).repeat(2, 1, 1, 1)
+
+    patches = pixel_values.reshape(
+        grid_t,
+        temporal_patch_size,
+        channel,
+        grid_h // merge_size,
+        merge_size,
+        patch_size,
+        grid_w // merge_size,
+        merge_size,
+        patch_size,
+    )
+
+    patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
+    flatten_patches = patches.reshape(grid_t * grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size)
+
+    return flatten_patches, image_grid_thw
+
+
+class VisionPatchEmbed(nn.Cell):
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        embed_dim: int = 3584,
+        device=None,
+        dtype=None,
+        ops=None,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.in_channels = in_channels
+        self.embed_dim = embed_dim
+
+        kernel_size = [temporal_patch_size, patch_size, patch_size]
+        self.proj = ops.Conv3d(
+            in_channels, embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=False, dtype=dtype
+        )
+
+    def construct(self, hidden_states: mindspore.Tensor) -> mindspore.Tensor:
+        hidden_states = hidden_states.view(
+            -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size
+        )
+        hidden_states = self.proj(hidden_states)
+        return hidden_states.view(-1, self.embed_dim)
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return mint.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class VisionRotaryEmbedding(nn.Cell):
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+
+    def construct(self, seqlen: int) -> mindspore.Tensor:
+        inv_freq = 1.0 / (self.theta ** (mint.arange(0, self.dim, 2, dtype=mindspore.float32) / self.dim))
+        seq = mint.arange(seqlen, dtype=inv_freq.dtype)
+        freqs = mint.outer(seq, inv_freq)
+        return freqs
+
+
+class PatchMerger(nn.Cell):
+    def __init__(self, dim: int, context_dim: int, spatial_merge_size: int = 2, device=None, dtype=None, ops=None):
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.ln_q = ops.RMSNorm(context_dim, eps=1e-6, dtype=dtype)
+        self.mlp = nn.SequentialCell(
+            ops.Linear(self.hidden_size, self.hidden_size, dtype=dtype),
+            mint.nn.GELU(),
+            ops.Linear(self.hidden_size, dim, dtype=dtype),
+        )
+
+    def construct(self, x: mindspore.Tensor) -> mindspore.Tensor:
+        x = self.ln_q(x).reshape(-1, self.hidden_size)
+        x = self.mlp(x)
+        return x
+
+
+class VisionAttention(nn.Cell):
+    def __init__(self, hidden_size: int, num_heads: int, device=None, dtype=None, ops=None):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.scaling = self.head_dim**-0.5
+
+        self.qkv = ops.Linear(hidden_size, hidden_size * 3, bias=True, dtype=dtype)
+        self.proj = ops.Linear(hidden_size, hidden_size, bias=True, dtype=dtype)
+
+    def construct(
+        self,
+        hidden_states: mindspore.Tensor,
+        position_embeddings: Optional[Tuple[mindspore.Tensor, mindspore.Tensor]] = None,
+        cu_seqlens=None,
+        optimized_attention=None,
+    ) -> mindspore.Tensor:
+        if hidden_states.dim() == 2:
+            seq_length, _ = hidden_states.shape
+            batch_size = 1
+            hidden_states = hidden_states.unsqueeze(0)
+        else:
+            batch_size, seq_length, _ = hidden_states.shape
+
+        qkv = self.qkv(hidden_states)
+        qkv = qkv.reshape(batch_size, seq_length, 3, self.num_heads, self.head_dim)
+        query_states, key_states, value_states = (
+            qkv.reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+        )
+
+        if position_embeddings is not None:
+            cos, sin = position_embeddings
+            query_states, key_states = apply_rotary_pos_emb_vision(query_states, key_states, cos, sin)
+
+        query_states = query_states.transpose(0, 1).unsqueeze(0)
+        key_states = key_states.transpose(0, 1).unsqueeze(0)
+        value_states = value_states.transpose(0, 1).unsqueeze(0)
+
+        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        splits = [mint.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)]
+
+        attn_outputs = [optimized_attention(q, k, v, self.num_heads, skip_reshape=True) for q, k, v in zip(*splits)]
+        attn_output = mint.cat(attn_outputs, dim=1)
+        attn_output = attn_output.reshape(seq_length, -1)
+        attn_output = self.proj(attn_output)
+
+        return attn_output
+
+
+class VisionMLP(nn.Cell):
+    def __init__(self, hidden_size: int, intermediate_size: int, device=None, dtype=None, ops=None):
+        super().__init__()
+        self.gate_proj = ops.Linear(hidden_size, intermediate_size, bias=True, dtype=dtype)
+        self.up_proj = ops.Linear(hidden_size, intermediate_size, bias=True, dtype=dtype)
+        self.down_proj = ops.Linear(intermediate_size, hidden_size, bias=True, dtype=dtype)
+        self.act_fn = mint.nn.SiLU()
+
+    def construct(self, hidden_state):
+        return self.down_proj(self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state))
+
+
+class VisionBlock(nn.Cell):
+    def __init__(self, hidden_size: int, intermediate_size: int, num_heads: int, device=None, dtype=None, ops=None):
+        super().__init__()
+        self.norm1 = ops.RMSNorm(hidden_size, eps=1e-6, dtype=dtype)
+        self.norm2 = ops.RMSNorm(hidden_size, eps=1e-6, dtype=dtype)
+        self.attn = VisionAttention(hidden_size, num_heads, device=None, dtype=dtype, ops=ops)
+        self.mlp = VisionMLP(hidden_size, intermediate_size, device=None, dtype=dtype, ops=ops)
+
+    def construct(
+        self,
+        hidden_states: mindspore.Tensor,
+        position_embeddings: Optional[Tuple[mindspore.Tensor, mindspore.Tensor]] = None,
+        cu_seqlens=None,
+        optimized_attention=None,
+    ) -> mindspore.Tensor:
+        residual = hidden_states
+        hidden_states = self.norm1(hidden_states)
+        hidden_states = self.attn(hidden_states, position_embeddings, cu_seqlens, optimized_attention)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class Qwen2VLVisionTransformer(nn.Cell):
+    def __init__(
+        self,
+        hidden_size: int = 3584,
+        output_hidden_size: int = 3584,
+        intermediate_size: int = 3420,
+        num_heads: int = 16,
+        num_layers: int = 32,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        spatial_merge_size: int = 2,
+        window_size: int = 112,
+        device=None,
+        dtype=None,
+        ops=None,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.patch_size = patch_size
+        self.spatial_merge_size = spatial_merge_size
+        self.window_size = window_size
+        self.fullatt_block_indexes = [7, 15, 23, 31]
+
+        self.patch_embed = VisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=3,
+            embed_dim=hidden_size,
+            device=None,
+            dtype=dtype,
+            ops=ops,
+        )
+
+        head_dim = hidden_size // num_heads
+        self.rotary_pos_emb = VisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.CellList(
+            [VisionBlock(hidden_size, intermediate_size, num_heads, device, dtype, ops) for _ in range(num_layers)]
+        )
+
+        self.merger = PatchMerger(
+            dim=output_hidden_size,
+            context_dim=hidden_size,
+            spatial_merge_size=spatial_merge_size,
+            device=None,
+            dtype=dtype,
+            ops=ops,
+        )
+
+    def get_window_index(self, grid_thw):
+        window_index = []
+        cu_window_seqlens = [0]
+        window_index_id = 0
+        vit_merger_window_size = self.window_size // self.spatial_merge_size // self.patch_size
+
+        for grid_t, grid_h, grid_w in grid_thw:
+            llm_grid_h = grid_h // self.spatial_merge_size
+            llm_grid_w = grid_w // self.spatial_merge_size
+
+            index = mint.arange(grid_t * llm_grid_h * llm_grid_w).reshape(grid_t, llm_grid_h, llm_grid_w)
+
+            pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size
+            pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size
+            num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+            num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+
+            index_padded = F.pad(index, (0, pad_w, 0, pad_h), "constant", -100)
+            index_padded = index_padded.reshape(
+                grid_t,
+                num_windows_h,
+                vit_merger_window_size,
+                num_windows_w,
+                vit_merger_window_size,
+            )
+            index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+                grid_t,
+                num_windows_h * num_windows_w,
+                vit_merger_window_size,
+                vit_merger_window_size,
+            )
+
+            seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+            index_padded = index_padded.reshape(-1)
+            index_new = index_padded[index_padded != -100]
+            window_index.append(index_new + window_index_id)
+
+            cu_seqlens_tmp = (
+                seqlens.cumsum(0) * self.spatial_merge_size * self.spatial_merge_size + cu_window_seqlens[-1]
+            )
+            cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+            window_index_id += (grid_t * llm_grid_h * llm_grid_w).item()
+
+        window_index = mint.cat(window_index, dim=0)
+        return window_index, cu_window_seqlens
+
+    def get_position_embeddings(self, grid_thw, device):
+        pos_ids = []
+
+        for t, h, w in grid_thw:
+            hpos_ids = mint.arange(h).unsqueeze(1).expand((-1, w))
+            hpos_ids = hpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            hpos_ids = hpos_ids.permute(0, 2, 1, 3).flatten()
+
+            wpos_ids = mint.arange(w).unsqueeze(0).expand((h, -1))
+            wpos_ids = wpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            wpos_ids = wpos_ids.permute(0, 2, 1, 3).flatten()
+
+            pos_ids.append(mint.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+
+        pos_ids = mint.cat(pos_ids, dim=0)
+        max_grid_size = grid_thw[:, 1:].max()
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        return rotary_pos_emb_full[pos_ids].flatten(1)
+
+    def construct(
+        self,
+        pixel_values: mindspore.Tensor,
+        image_grid_thw: Optional[mindspore.Tensor] = None,
+    ) -> mindspore.Tensor:
+        optimized_attention = optimized_attention_for_device(None, mask=False, small_input=True)
+
+        hidden_states = self.patch_embed(pixel_values)
+
+        window_index, cu_window_seqlens = self.get_window_index(image_grid_thw)
+        cu_window_seqlens = mindspore.tensor(cu_window_seqlens)
+        cu_window_seqlens = mint.unique_consecutive(cu_window_seqlens)
+
+        position_embeddings = self.get_position_embeddings(image_grid_thw, None)
+
+        seq_len, _ = hidden_states.size()
+        spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+
+        hidden_states = hidden_states.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+        hidden_states = hidden_states[window_index, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+
+        position_embeddings = position_embeddings.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+        position_embeddings = position_embeddings[window_index, :, :]
+        position_embeddings = position_embeddings.reshape(seq_len, -1)
+        position_embeddings = mint.cat((position_embeddings, position_embeddings), dim=-1)
+        position_embeddings = (position_embeddings.cos(), position_embeddings.sin())
+
+        cu_seqlens = mint.repeat_interleave(image_grid_thw[:, 1] * image_grid_thw[:, 2], image_grid_thw[:, 0]).cumsum(
+            dim=0,
+            dtype=mindspore.int32,
+        )
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+
+        for i, block in enumerate(self.blocks):
+            if i in self.fullatt_block_indexes:
+                cu_seqlens_now = cu_seqlens
+            else:
+                cu_seqlens_now = cu_window_seqlens
+            hidden_states = block(
+                hidden_states, position_embeddings, cu_seqlens_now, optimized_attention=optimized_attention
+            )
+
+        hidden_states = self.merger(hidden_states)
+        return hidden_states

--- a/mindone/comfyui/comfy/text_encoders/sd3_clip.py
+++ b/mindone/comfyui/comfy/text_encoders/sd3_clip.py
@@ -1,0 +1,180 @@
+import logging
+import os
+
+import comfy.model_management
+import comfy.text_encoders.t5
+from comfy import sd1_clip, sdxl_clip
+from transformers import T5TokenizerFast
+
+import mindspore
+
+
+class T5XXLModel(sd1_clip.SDClipModel):
+    def __init__(self, layer="last", layer_idx=None, dtype=None, attention_mask=False, model_options={}):
+        textmodel_json_config = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_config_xxl.json")
+        t5xxl_scaled_fp8 = model_options.get("t5xxl_scaled_fp8", None)
+        if t5xxl_scaled_fp8 is not None:
+            # model_options = model_options.copy()
+            # model_options["scaled_fp8"] = t5xxl_scaled_fp8
+            raise NotImplementedError
+
+        model_options = {**model_options, "model_name": "t5xxl"}
+        super().__init__(
+            layer=layer,
+            layer_idx=layer_idx,
+            textmodel_json_config=textmodel_json_config,
+            dtype=dtype,
+            special_tokens={"end": 1, "pad": 0},
+            model_class=comfy.text_encoders.t5.T5,
+            enable_attention_masks=attention_mask,
+            return_attention_masks=attention_mask,
+            model_options=model_options,
+        )
+
+
+def t5_xxl_detect(state_dict, prefix=""):
+    out = {}
+    t5_key = "{}encoder.final_layer_norm.weight".format(prefix)
+    if t5_key in state_dict:
+        out["dtype_t5"] = state_dict[t5_key].dtype
+
+    scaled_fp8_key = "{}scaled_fp8".format(prefix)
+    if scaled_fp8_key in state_dict:
+        out["t5xxl_scaled_fp8"] = state_dict[scaled_fp8_key].dtype
+
+    return out
+
+
+# class T5XXLTokenizer(sd1_clip.SDTokenizer):
+#     def __init__(self, embedding_directory=None, tokenizer_data={}, min_length=77, max_length=99999999):
+#         tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_tokenizer")
+#         super().__init__(tokenizer_path, embedding_directory=embedding_directory, pad_with_end=False, embedding_size=4096, embedding_key='t5xxl', tokenizer_class=T5TokenizerFast, has_start_token=False, pad_to_max_length=False, max_length=max_length, min_length=min_length, tokenizer_data=tokenizer_data)
+
+
+# class SD3Tokenizer:
+#     def __init__(self, embedding_directory=None, tokenizer_data={}):
+#         self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+#         self.clip_g = sdxl_clip.SDXLClipGTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+#         self.t5xxl = T5XXLTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
+
+#     def tokenize_with_weights(self, text:str, return_word_ids=False, **kwargs):
+#         out = {}
+#         out["g"] = self.clip_g.tokenize_with_weights(text, return_word_ids, **kwargs)
+#         out["l"] = self.clip_l.tokenize_with_weights(text, return_word_ids, **kwargs)
+#         out["t5xxl"] = self.t5xxl.tokenize_with_weights(text, return_word_ids, **kwargs)
+#         return out
+
+#     def untokenize(self, token_weight_pair):
+#         return self.clip_g.untokenize(token_weight_pair)
+
+#     def state_dict(self):
+#         return {}
+
+# class SD3ClipModel(torch.nn.Module):
+#     def __init__(self, clip_l=True, clip_g=True, t5=True, dtype_t5=None, t5_attention_mask=False, device="cpu", dtype=None, model_options={}):
+#         super().__init__()
+#         self.dtypes = set()
+#         if clip_l:
+#             self.clip_l = sd1_clip.SDClipModel(layer="hidden", layer_idx=-2, device=device, dtype=dtype, layer_norm_hidden_state=False, return_projected_pooled=False, model_options=model_options)
+#             self.dtypes.add(dtype)
+#         else:
+#             self.clip_l = None
+
+#         if clip_g:
+#             self.clip_g = sdxl_clip.SDXLClipG(device=device, dtype=dtype, model_options=model_options)
+#             self.dtypes.add(dtype)
+#         else:
+#             self.clip_g = None
+
+#         if t5:
+#             dtype_t5 = comfy.model_management.pick_weight_dtype(dtype_t5, dtype, device)
+#             self.t5_attention_mask = t5_attention_mask
+#             self.t5xxl = T5XXLModel(device=device, dtype=dtype_t5, model_options=model_options, attention_mask=self.t5_attention_mask)
+#             self.dtypes.add(dtype_t5)
+#         else:
+#             self.t5xxl = None
+
+#         logging.debug("Created SD3 text encoder with: clip_l {}, clip_g {}, t5xxl {}:{}".format(clip_l, clip_g, t5, dtype_t5))
+
+#     def set_clip_options(self, options):
+#         if self.clip_l is not None:
+#             self.clip_l.set_clip_options(options)
+#         if self.clip_g is not None:
+#             self.clip_g.set_clip_options(options)
+#         if self.t5xxl is not None:
+#             self.t5xxl.set_clip_options(options)
+
+#     def reset_clip_options(self):
+#         if self.clip_l is not None:
+#             self.clip_l.reset_clip_options()
+#         if self.clip_g is not None:
+#             self.clip_g.reset_clip_options()
+#         if self.t5xxl is not None:
+#             self.t5xxl.reset_clip_options()
+
+#     def encode_token_weights(self, token_weight_pairs):
+#         token_weight_pairs_l = token_weight_pairs["l"]
+#         token_weight_pairs_g = token_weight_pairs["g"]
+#         token_weight_pairs_t5 = token_weight_pairs["t5xxl"]
+#         lg_out = None
+#         pooled = None
+#         out = None
+#         extra = {}
+
+#         if len(token_weight_pairs_g) > 0 or len(token_weight_pairs_l) > 0:
+#             if self.clip_l is not None:
+#                 lg_out, l_pooled = self.clip_l.encode_token_weights(token_weight_pairs_l)
+#             else:
+#                 l_pooled = torch.zeros((1, 768), device=comfy.model_management.intermediate_device())
+
+#             if self.clip_g is not None:
+#                 g_out, g_pooled = self.clip_g.encode_token_weights(token_weight_pairs_g)
+#                 if lg_out is not None:
+#                     cut_to = min(lg_out.shape[1], g_out.shape[1])
+#                     lg_out = torch.cat([lg_out[:,:cut_to], g_out[:,:cut_to]], dim=-1)
+#                 else:
+#                     lg_out = torch.nn.functional.pad(g_out, (768, 0))
+#             else:
+#                 g_out = None
+#                 g_pooled = torch.zeros((1, 1280), device=comfy.model_management.intermediate_device())
+
+#             if lg_out is not None:
+#                 lg_out = torch.nn.functional.pad(lg_out, (0, 4096 - lg_out.shape[-1]))
+#                 out = lg_out
+#             pooled = torch.cat((l_pooled, g_pooled), dim=-1)
+
+#         if self.t5xxl is not None:
+#             t5_output = self.t5xxl.encode_token_weights(token_weight_pairs_t5)
+#             t5_out, t5_pooled = t5_output[:2]
+#             if self.t5_attention_mask:
+#                 extra["attention_mask"] = t5_output[2]["attention_mask"]
+
+#             if lg_out is not None:
+#                 out = torch.cat([lg_out, t5_out], dim=-2)
+#             else:
+#                 out = t5_out
+
+#         if out is None:
+#             out = torch.zeros((1, 77, 4096), device=comfy.model_management.intermediate_device())
+
+#         if pooled is None:
+#             pooled = torch.zeros((1, 768 + 1280), device=comfy.model_management.intermediate_device())
+
+#         return out, pooled, extra
+
+#     def load_sd(self, sd):
+#         if "text_model.encoder.layers.30.mlp.fc1.weight" in sd:
+#             return self.clip_g.load_sd(sd)
+#         elif "text_model.encoder.layers.1.mlp.fc1.weight" in sd:
+#             return self.clip_l.load_sd(sd)
+#         else:
+#             return self.t5xxl.load_sd(sd)
+
+# def sd3_clip(clip_l=True, clip_g=True, t5=True, dtype_t5=None, t5xxl_scaled_fp8=None, t5_attention_mask=False):
+#     class SD3ClipModel_(SD3ClipModel):
+#         def __init__(self, device="cpu", dtype=None, model_options={}):
+#             if t5xxl_scaled_fp8 is not None and "t5xxl_scaled_fp8" not in model_options:
+#                 model_options = model_options.copy()
+#                 model_options["t5xxl_scaled_fp8"] = t5xxl_scaled_fp8
+#             super().__init__(clip_l=clip_l, clip_g=clip_g, t5=t5, dtype_t5=dtype_t5, t5_attention_mask=t5_attention_mask, device=device, dtype=dtype, model_options=model_options)
+#     return SD3ClipModel_

--- a/mindone/comfyui/comfy/text_encoders/t5.py
+++ b/mindone/comfyui/comfy/text_encoders/t5.py
@@ -1,0 +1,328 @@
+import math
+
+import comfy.ops
+from comfy.ldm.modules.attention import optimized_attention_for_device
+from mindspore_patch.utils import dtype_to_max
+
+import mindspore
+from mindspore import mint
+
+
+class T5LayerNorm(mindspore.nn.Cell):
+    def __init__(self, hidden_size, eps=1e-6, dtype=None, operations=None):
+        super().__init__()
+        self.weight = mindspore.Parameter(mint.empty(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def construct(self, x):
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * mint.rsqrt(variance + self.variance_epsilon)
+        return comfy.ops.cast_to_input(self.weight, x) * x
+
+
+activations = {
+    "gelu_pytorch_tanh": lambda a: mint.functional.gelu(a, approximate="tanh"),
+    "relu": mint.functional.relu,
+}
+
+
+class T5DenseActDense(mindspore.nn.Cell):
+    def __init__(self, model_dim, ff_dim, ff_activation, dtype, operations):
+        super().__init__()
+        self.wi = operations.Linear(model_dim, ff_dim, bias=False, dtype=dtype)
+        self.wo = operations.Linear(ff_dim, model_dim, bias=False, dtype=dtype)
+        # self.dropout = nn.Dropout(config.dropout_rate)
+        self.act = activations[ff_activation]
+
+    def construct(self, x):
+        x = self.act(self.wi(x))
+        # x = self.dropout(x)
+        x = self.wo(x)
+        return x
+
+
+class T5DenseGatedActDense(mindspore.nn.Cell):
+    def __init__(self, model_dim, ff_dim, ff_activation, dtype, operations):
+        super().__init__()
+        self.wi_0 = operations.Linear(model_dim, ff_dim, bias=False, dtype=dtype)
+        self.wi_1 = operations.Linear(model_dim, ff_dim, bias=False, dtype=dtype)
+        self.wo = operations.Linear(ff_dim, model_dim, bias=False, dtype=dtype)
+        # self.dropout = nn.Dropout(config.dropout_rate)
+        self.act = activations[ff_activation]
+
+    def construct(self, x):
+        hidden_gelu = self.act(self.wi_0(x))
+        hidden_linear = self.wi_1(x)
+        x = hidden_gelu * hidden_linear
+        # x = self.dropout(x)
+        x = self.wo(x)
+        return x
+
+
+class T5LayerFF(mindspore.nn.Cell):
+    def __init__(self, model_dim, ff_dim, ff_activation, gated_act, dtype, operations):
+        super().__init__()
+        if gated_act:
+            self.DenseReluDense = T5DenseGatedActDense(model_dim, ff_dim, ff_activation, dtype, operations)
+        else:
+            self.DenseReluDense = T5DenseActDense(model_dim, ff_dim, ff_activation, dtype, operations)
+
+        self.layer_norm = T5LayerNorm(model_dim, dtype=dtype, operations=operations)
+        # self.dropout = nn.Dropout(config.dropout_rate)
+
+    def construct(self, x):
+        forwarded_states = self.layer_norm(x)
+        forwarded_states = self.DenseReluDense(forwarded_states)
+        # x = x + self.dropout(forwarded_states)
+        x += forwarded_states
+        return x
+
+
+class T5Attention(mindspore.nn.Cell):
+    def __init__(self, model_dim, inner_dim, num_heads, relative_attention_bias, dtype, operations):
+        super().__init__()
+
+        # Mesh TensorFlow initialization to avoid scaling before softmax
+        self.q = operations.Linear(model_dim, inner_dim, bias=False, dtype=dtype)
+        self.k = operations.Linear(model_dim, inner_dim, bias=False, dtype=dtype)
+        self.v = operations.Linear(model_dim, inner_dim, bias=False, dtype=dtype)
+        self.o = operations.Linear(inner_dim, model_dim, bias=False, dtype=dtype)
+        self.num_heads = num_heads
+
+        self.relative_attention_bias = None
+        if relative_attention_bias:
+            self.relative_attention_num_buckets = 32
+            self.relative_attention_max_distance = 128
+            self.relative_attention_bias = operations.Embedding(
+                self.relative_attention_num_buckets, self.num_heads, dtype=dtype
+            )
+
+    @staticmethod
+    def _relative_position_bucket(relative_position, bidirectional=True, num_buckets=32, max_distance=128):
+        """
+        Adapted from Mesh Tensorflow:
+        https://github.com/tensorflow/mesh/blob/0cb87fe07da627bf0b7e60475d59f95ed6b5be3d/mesh_tensorflow/transformer/transformer_layers.py#L593
+
+        Translate relative position to a bucket number for relative attention. The relative position is defined as
+        memory_position - query_position, i.e. the distance in tokens from the attending position to the attended-to
+        position. If bidirectional=False, then positive relative positions are invalid. We use smaller buckets for
+        small absolute relative_position and larger buckets for larger absolute relative_positions. All relative
+        positions >=max_distance map to the same bucket. All relative positions <=-max_distance map to the same bucket.
+        This should allow for more graceful generalization to longer sequences than the model has been trained on
+
+        Args:
+            relative_position: an int32 Tensor
+            bidirectional: a boolean - whether the attention is bidirectional
+            num_buckets: an integer
+            max_distance: an integer
+
+        Returns:
+            a Tensor with the same shape as relative_position, containing int32 values in the range [0, num_buckets)
+        """
+        relative_buckets = 0
+        if bidirectional:
+            num_buckets //= 2
+            relative_buckets += (relative_position > 0).to(mindspore.long) * num_buckets
+            relative_position = mint.abs(relative_position)
+        else:
+            relative_position = -mint.min(relative_position, mint.zeros_like(relative_position))
+        # now relative_position is in the range [0, inf)
+
+        # half of the buckets are for exact increments in positions
+        max_exact = num_buckets // 2
+        is_small = relative_position < max_exact
+
+        # The other half of the buckets are for logarithmically bigger bins in positions up to max_distance
+        relative_position_if_large = max_exact + (
+            mint.log(relative_position.float() / max_exact)
+            / math.log(max_distance / max_exact)
+            * (num_buckets - max_exact)
+        ).to(mindspore.long)
+        relative_position_if_large = mint.min(
+            relative_position_if_large, mint.full_like(relative_position_if_large, num_buckets - 1)
+        )
+
+        relative_buckets += mint.where(is_small, relative_position, relative_position_if_large)
+        return relative_buckets
+
+    def compute_bias(self, query_length, key_length, dtype):
+        """Compute binned relative position bias"""
+        context_position = mint.arange(query_length, dtype=mindspore.long)[:, None]
+        memory_position = mint.arange(key_length, dtype=mindspore.long)[None, :]
+        relative_position = memory_position - context_position  # shape (query_length, key_length)
+        relative_position_bucket = self._relative_position_bucket(
+            relative_position,  # shape (query_length, key_length)
+            bidirectional=True,
+            num_buckets=self.relative_attention_num_buckets,
+            max_distance=self.relative_attention_max_distance,
+        )
+        values = self.relative_attention_bias(
+            relative_position_bucket, out_dtype=dtype
+        )  # shape (query_length, key_length, num_heads)
+        values = values.permute([2, 0, 1]).unsqueeze(0)  # shape (1, num_heads, query_length, key_length)
+        return values.contiguous()
+
+    def construct(self, x, mask=None, past_bias=None, optimized_attention=None):
+        q = self.q(x)
+        k = self.k(x)
+        v = self.v(x)
+        if self.relative_attention_bias is not None:
+            past_bias = self.compute_bias(x.shape[1], x.shape[1], x.dtype)
+
+        if past_bias is not None:
+            if mask is not None:
+                mask = mask + past_bias
+            else:
+                mask = past_bias
+
+        out = optimized_attention(q, k * ((k.shape[-1] / self.num_heads) ** 0.5), v, self.num_heads, mask)
+        return self.o(out), past_bias
+
+
+class T5LayerSelfAttention(mindspore.nn.Cell):
+    def __init__(self, model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias, dtype, operations):
+        super().__init__()
+        self.SelfAttention = T5Attention(model_dim, inner_dim, num_heads, relative_attention_bias, dtype, operations)
+        self.layer_norm = T5LayerNorm(model_dim, dtype=dtype, operations=operations)
+        # self.dropout = nn.Dropout(config.dropout_rate)
+
+    def construct(self, x, mask=None, past_bias=None, optimized_attention=None):
+        output, past_bias = self.SelfAttention(
+            self.layer_norm(x), mask=mask, past_bias=past_bias, optimized_attention=optimized_attention
+        )
+        # x = x + self.dropout(attention_output)
+        x += output
+        return x, past_bias
+
+
+class T5Block(mindspore.nn.Cell):
+    def __init__(
+        self,
+        model_dim,
+        inner_dim,
+        ff_dim,
+        ff_activation,
+        gated_act,
+        num_heads,
+        relative_attention_bias,
+        dtype,
+        operations,
+    ):
+        super().__init__()
+        self.layer = mindspore.nn.CellList()
+        self.layer.append(
+            T5LayerSelfAttention(model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias, dtype, operations)
+        )
+        self.layer.append(T5LayerFF(model_dim, ff_dim, ff_activation, gated_act, dtype, operations))
+
+    def construct(self, x, mask=None, past_bias=None, optimized_attention=None):
+        x, past_bias = self.layer[0](x, mask, past_bias, optimized_attention)
+        x = self.layer[-1](x)
+        return x, past_bias
+
+
+class T5Stack(mindspore.nn.Cell):
+    def __init__(
+        self,
+        num_layers,
+        model_dim,
+        inner_dim,
+        ff_dim,
+        ff_activation,
+        gated_act,
+        num_heads,
+        relative_attention,
+        dtype,
+        operations,
+    ):
+        super().__init__()
+
+        self.block = mindspore.nn.CellList(
+            [
+                T5Block(
+                    model_dim,
+                    inner_dim,
+                    ff_dim,
+                    ff_activation,
+                    gated_act,
+                    num_heads,
+                    relative_attention_bias=((not relative_attention) or (i == 0)),
+                    dtype=dtype,
+                    operations=operations,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_layer_norm = T5LayerNorm(model_dim, dtype=dtype, operations=operations)
+        # self.dropout = nn.Dropout(config.dropout_rate)
+
+    def construct(
+        self,
+        x,
+        attention_mask=None,
+        intermediate_output=None,
+        final_layer_norm_intermediate=True,
+        dtype=None,
+        embeds_info=[],
+    ):
+        mask = None
+        if attention_mask is not None:
+            mask = 1.0 - attention_mask.to(x.dtype).reshape(
+                (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
+            ).expand((attention_mask.shape[0], 1, attention_mask.shape[-1], attention_mask.shape[-1]))
+            mask = mask.masked_fill(mask.to(mindspore.bool), -dtype_to_max(x.dtype))
+
+        intermediate = None
+        optimized_attention = optimized_attention_for_device(None, mask=attention_mask is not None, small_input=True)
+        past_bias = None
+
+        if intermediate_output is not None:
+            if intermediate_output < 0:
+                intermediate_output = len(self.block) + intermediate_output
+
+        for i, l in enumerate(self.block):
+            x, past_bias = l(x, mask, past_bias, optimized_attention)
+            if i == intermediate_output:
+                intermediate = x.clone()
+        x = self.final_layer_norm(x)
+        if intermediate is not None and final_layer_norm_intermediate:
+            intermediate = self.final_layer_norm(intermediate)
+        return x, intermediate
+
+
+class T5(mindspore.nn.Cell):
+    def __init__(self, config_dict, dtype, device, operations):
+        super().__init__()
+        self.num_layers = config_dict["num_layers"]
+        model_dim = config_dict["d_model"]
+        inner_dim = config_dict["d_kv"] * config_dict["num_heads"]
+
+        self.encoder = T5Stack(
+            self.num_layers,
+            model_dim,
+            inner_dim,
+            config_dict["d_ff"],
+            config_dict["dense_act_fn"],
+            config_dict["is_gated_act"],
+            config_dict["num_heads"],
+            config_dict["model_type"] != "umt5",
+            dtype,
+            operations,
+        )
+        self.dtype = dtype
+        self.shared = operations.Embedding(config_dict["vocab_size"], model_dim, dtype=dtype)
+
+    def get_input_embeddings(self):
+        return self.shared
+
+    def set_input_embeddings(self, embeddings):
+        self.shared = embeddings
+
+    def construct(self, input_ids, attention_mask, embeds=None, num_tokens=None, **kwargs):
+        if input_ids is None:
+            x = embeds
+        else:
+            x = self.shared(input_ids, out_dtype=kwargs.get("dtype", mindspore.float32))
+        if self.dtype not in [mindspore.float32, mindspore.float16, mindspore.bfloat16]:
+            x = mint.nan_to_num(x)  # Fix for fp8 T5 base
+        return self.encoder(x, attention_mask=attention_mask, **kwargs)


### PR DESCRIPTION
## Description
Add text encoder files for mindone/comfyui.

## Changes
- ✅ Add 8 text encoder files: bert, flux, hunyuan_video, llama, qwen_image, qwen_vl, sd3_clip, t5

## Files Added
- `mindone/comfyui/comfy/text_encoders/bert.py`
- `mindone/comfyui/comfy/text_encoders/flux.py`
- `mindone/comfyui/comfy/text_encoders/hunyuan_video.py`
- `mindone/comfyui/comfy/text_encoders/llama.py`
- `mindone/comfyui/comfy/text_encoders/qwen_image.py`
- `mindone/comfyui/comfy/text_encoders/qwen_vl.py`
- `mindone/comfyui/comfy/text_encoders/sd3_clip.py`
- `mindone/comfyui/comfy/text_encoders/t5.py`

## Checklist
- [x] Code follows project coding standards
- [x] Files properly organized in directory structure same as comfyui