### PR TITLE
fix(diffusers): update md and fix dtype mismatch of qwenimage

### DIFF
--- a/docs/diffusers/api/pipelines/qwenimage.md
+++ b/docs/diffusers/api/pipelines/qwenimage.md
@@ -26,6 +26,7 @@ Qwen-Image comes in the following variants:
 |:----------:|:--------:|
 | Qwen-Image | [`Qwen/Qwen-Image`](https://huggingface.co/Qwen/Qwen-Image) |
 | Qwen-Image-Edit | [`Qwen/Qwen-Image-Edit`](https://huggingface.co/Qwen/Qwen-Image-Edit) |
+| Qwen-Image-Edit Plus | [Qwen/Qwen-Image-Edit-2509](https://huggingface.co/Qwen/Qwen-Image-Edit-2509) |
 
 !!! tip
 

--- a/docs/diffusers/api/pipelines/qwenimage.md
+++ b/docs/diffusers/api/pipelines/qwenimage.md
@@ -26,7 +26,7 @@ Qwen-Image comes in the following variants:
 |:----------:|:--------:|
 | Qwen-Image | [`Qwen/Qwen-Image`](https://huggingface.co/Qwen/Qwen-Image) |
 | Qwen-Image-Edit | [`Qwen/Qwen-Image-Edit`](https://huggingface.co/Qwen/Qwen-Image-Edit) |
-| Qwen-Image-Edit Plus | [Qwen/Qwen-Image-Edit-2509](https://huggingface.co/Qwen/Qwen-Image-Edit-2509) |
+| Qwen-Image-Edit Plus | [`Qwen/Qwen-Image-Edit-2509`](https://huggingface.co/Qwen/Qwen-Image-Edit-2509) |
 
 !!! tip
 

--- a/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage.py
@@ -652,11 +652,11 @@ class QwenImagePipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = t.expand((latents.shape[0],)).to(latents.dtype)
                 noise_pred = self.transformer(
-                    hidden_states=latents,
+                    hidden_states=latents.to(self.transformer.dtype),
                     timestep=timestep / 1000,
                     guidance=guidance,
                     encoder_hidden_states_mask=prompt_embeds_mask,
-                    encoder_hidden_states=prompt_embeds,
+                    encoder_hidden_states=prompt_embeds.to(self.transformer.dtype),
                     img_shapes=img_shapes,
                     txt_seq_lens=txt_seq_lens,
                     attention_kwargs=self.attention_kwargs,
@@ -665,11 +665,11 @@ class QwenImagePipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
 
                 if do_true_cfg:
                     neg_noise_pred = self.transformer(
-                        hidden_states=latents,
+                        hidden_states=latents.to(self.transformer.dtype),
                         timestep=timestep / 1000,
                         guidance=guidance,
                         encoder_hidden_states_mask=negative_prompt_embeds_mask,
-                        encoder_hidden_states=negative_prompt_embeds,
+                        encoder_hidden_states=negative_prompt_embeds.to(self.transformer.dtype),
                         img_shapes=img_shapes,
                         txt_seq_lens=negative_txt_seq_lens,
                         attention_kwargs=self.attention_kwargs,

--- a/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
+++ b/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
@@ -780,11 +780,11 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = t.expand((latents.shape[0],)).to(latents.dtype)
                 noise_pred = self.transformer(
-                    hidden_states=latent_model_input,
+                    hidden_states=latent_model_input.to(self.transformer.dtype),
                     timestep=timestep / 1000,
                     guidance=guidance,
                     encoder_hidden_states_mask=prompt_embeds_mask,
-                    encoder_hidden_states=prompt_embeds,
+                    encoder_hidden_states=prompt_embeds.to(self.transformer.dtype),
                     img_shapes=img_shapes,
                     txt_seq_lens=txt_seq_lens,
                     attention_kwargs=self.attention_kwargs,
@@ -794,11 +794,11 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
 
                 if do_true_cfg:
                     neg_noise_pred = self.transformer(
-                        hidden_states=latent_model_input,
+                        hidden_states=latent_model_input.to(self.transformer.dtype),
                         timestep=timestep / 1000,
                         guidance=guidance,
                         encoder_hidden_states_mask=negative_prompt_embeds_mask,
-                        encoder_hidden_states=negative_prompt_embeds,
+                        encoder_hidden_states=negative_prompt_embeds.to(self.transformer.dtype),
                         img_shapes=img_shapes,
                         txt_seq_lens=negative_txt_seq_lens,
                         attention_kwargs=self.attention_kwargs,

--- a/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
+++ b/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
@@ -991,11 +991,11 @@ class QwenImageEditInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = t.expand((latents.shape[0],)).to(latents.dtype)
                 noise_pred = self.transformer(
-                    hidden_states=latent_model_input,
+                    hidden_states=latent_model_input.to(self.transformer.dtype),
                     timestep=timestep / 1000,
                     guidance=guidance,
                     encoder_hidden_states_mask=prompt_embeds_mask,
-                    encoder_hidden_states=prompt_embeds,
+                    encoder_hidden_states=prompt_embeds.to(self.transformer.dtype),
                     img_shapes=img_shapes,
                     txt_seq_lens=txt_seq_lens,
                     attention_kwargs=self.attention_kwargs,
@@ -1005,11 +1005,11 @@ class QwenImageEditInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
 
                 if do_true_cfg:
                     neg_noise_pred = self.transformer(
-                        hidden_states=latent_model_input,
+                        hidden_states=latent_model_input.to(self.transformer.dtype),
                         timestep=timestep / 1000,
                         guidance=guidance,
                         encoder_hidden_states_mask=negative_prompt_embeds_mask,
-                        encoder_hidden_states=negative_prompt_embeds,
+                        encoder_hidden_states=negative_prompt_embeds.to(self.transformer.dtype),
                         img_shapes=img_shapes,
                         txt_seq_lens=negative_txt_seq_lens,
                         attention_kwargs=self.attention_kwargs,

--- a/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_img2img.py
+++ b/mindone/diffusers/pipelines/qwenimage/pipeline_qwenimage_img2img.py
@@ -751,11 +751,11 @@ class QwenImageImg2ImgPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = t.expand((latents.shape[0],)).to(latents.dtype)
                 noise_pred = self.transformer(
-                    hidden_states=latents,
+                    hidden_states=latents.to(self.transformer.dtype),
                     timestep=timestep / 1000,
                     guidance=guidance,
                     encoder_hidden_states_mask=prompt_embeds_mask,
-                    encoder_hidden_states=prompt_embeds,
+                    encoder_hidden_states=prompt_embeds.to(self.transformer.dtype),
                     img_shapes=img_shapes,
                     txt_seq_lens=txt_seq_lens,
                     attention_kwargs=self.attention_kwargs,
@@ -764,11 +764,11 @@ class QwenImageImg2ImgPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
 
                 if do_true_cfg:
                     neg_noise_pred = self.transformer(
-                        hidden_states=latents,
+                        hidden_states=latents.to(self.transformer.dtype),
                         timestep=timestep / 1000,
                         guidance=guidance,
                         encoder_hidden_states_mask=negative_prompt_embeds_mask,
-                        encoder_hidden_states=negative_prompt_embeds,
+                        encoder_hidden_states=negative_prompt_embeds.to(self.transformer.dtype),
                         img_shapes=img_shapes,
                         txt_seq_lens=negative_txt_seq_lens,
                         attention_kwargs=self.attention_kwargs,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Fixes
1. Update [qwenimage.md](https://github.com/mindspore-lab/mindone/pull/1495/changes#diff-91600edb29f22fd1e2e2ef526380bc0273c23d3c8b8560d7fa50cc82db6b654e): add `Qwen-Image-Edit Plus` to the md
2. Fix dtype mismatch in Transformer input under mixed precision: When using mixed precision for different components of the pipeline, the input latent states and prompt embeddings may be in a different dtype than the Transformer's weight dtype (e.g., float16 vs. float32). This mismatch can cause runtime errors during the forward pass. This change ensures that both `latents` and `prompt_embeds` are explicitly converted to the Transformer's `dtype` before being passed into the model.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/mindspore-lab/mindone/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? E.g. record bug fixes or new features in `What's New`. Here are the
      [documentation guidelines](https://github.com/mindspore-lab/mindcv/wiki/%E6%96%87%E6%A1%A3%E7%BC%96%E5%86%99%E8%A7%84%E8%8C%83)
- [ ] Did you build and run the code without any errors?
- [ ] Did you report the running environment (NPU type/MS version) and performance in the doc? (better record it for data loading, model inference, or training tasks)
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@xxx

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
-->
